### PR TITLE
Update vote.dm

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -16,7 +16,7 @@ SUBSYSTEM_DEF(vote)
 	var/list/voting = list()
 	var/list/generated_actions = list()
 	var/vote_sound = 'sound/f13/mysterious_stranger.ogg'
-	var/min_restart_time = 90 MINUTES
+	var/min_restart_time = 180 MINUTES
 
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)


### PR DESCRIPTION
Changes minimum time before players can make a restart vote from 1hr 30 to 3hrs.