### PR TITLE
Makes sunlight a bit longer in range

### DIFF
--- a/code/game/turfs/simulated/floor/f13_floors.dm
+++ b/code/game/turfs/simulated/floor/f13_floors.dm
@@ -30,7 +30,7 @@
 	desc = "If found, scream at the github repo about this"
 	icon_state = "wasteland1"
 	icon = 'icons/turf/f13desert.dmi'
-	turf_light_range = 3
+	turf_light_range = 6
 	turf_light_power = 0.75
 
 /* Outside turfs get global lighting */

--- a/code/modules/fallout/turf/ground.dm
+++ b/code/modules/fallout/turf/ground.dm
@@ -48,7 +48,7 @@
 //////////////////////////////////////////////////////////////////////
 
 /turf/open/indestructible/ground/outside
-	turf_light_range = 3
+	turf_light_range = 6
 	turf_light_power = 0.75
 
 /turf/open/indestructible/ground/outside/Initialize()


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Makes sunlight have more "range" (isn't a radius or diameter, go figure)
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
So buildings can have more sunlight going into it and it looks cool instead of right now where it's dinky
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Works on my end:tm:
## Screenshots (if appropriate):

## Changelog (necessary)
:cl: ma44
tweak: Sunlight goes into buildings more further
/:cl:
