### PR TITLE
Implements drag delay

### DIFF
--- a/code/game/atoms_movable.dm
+++ b/code/game/atoms_movable.dm
@@ -2,6 +2,7 @@
 	layer = OBJ_LAYER
 	var/last_move = null
 	var/anchored = FALSE
+	var/drag_delay = 0.3 SECONDS
 	var/datum/thrownthing/throwing = null
 	var/throw_speed = 2 //How many tiles to move per ds when being thrown. Float values are fully supported
 	var/throw_range = 7
@@ -107,20 +108,21 @@
 
 /atom/movable/proc/Move_Pulled(atom/A)
 	if(!pulling)
-		return
+		return FALSE
 	if(pulling.anchored || !pulling.Adjacent(src))
 		stop_pulling()
-		return
+		return FALSE
 	if(isliving(pulling))
 		var/mob/living/L = pulling
 		if(L.buckled && L.buckled.buckle_prevents_pull) //if they're buckled to something that disallows pulling, prevent it
 			stop_pulling()
-			return
+			return FALSE
 	if(A == loc && pulling.density)
-		return
+		return FALSE
 	if(!Process_Spacemove(get_dir(pulling.loc, A)))
-		return
+		return FALSE
 	step(pulling, get_dir(pulling.loc, A))
+	return TRUE
 
 /atom/movable/proc/check_pulling()
 	if(pulling)

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -71,7 +71,7 @@ Class Procs:
 	verb_yell = "blares"
 	pressure_resistance = 15
 	max_integrity = 200
-
+	drag_delay = 0.6 SECONDS
 	anchored = TRUE
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
 

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -7,6 +7,7 @@
 	icon_state = "iv_drip"
 	anchored = FALSE
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
+	drag_delay = 0.1 SECONDS
 	var/mob/living/carbon/attached = null
 	var/mode = IV_INJECTING
 	var/obj/item/reagent_containers/beaker = null

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -112,6 +112,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (!materials)
 		materials = list()
 	. = ..()
+	if(w_class <= WEIGHT_CLASS_NORMAL) //pulling small items doesn't slow you down much
+		drag_delay = 0.1 SECONDS
 	for(var/path in actions_types)
 		new path(src)
 	actions_types = null

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -3,6 +3,7 @@
 	pressure_resistance = 8
 	max_integrity = 300
 	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND | INTERACT_ATOM_UI_INTERACT
+	drag_delay = 0.6 SECONDS
 	var/climb_time = 20
 	var/climb_stun = 20
 	var/climbable = FALSE

--- a/code/game/objects/structures/beds_chairs/bed.dm
+++ b/code/game/objects/structures/beds_chairs/bed.dm
@@ -53,6 +53,7 @@
 	icon_state = "down"
 	anchored = FALSE
 	resistance_flags = NONE
+	drag_delay = 0 //Pulling something on wheels is easy
 	var/foldabletype = /obj/item/roller
 
 /obj/structure/bed/roller/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -217,6 +217,7 @@
 /obj/structure/chair/office
 	anchored = FALSE
 	buildstackamount = 5
+	drag_delay = 0.1 SECONDS //Pulling something on wheels is easy
 	item_chair = null
 
 

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -7,6 +7,7 @@
 	layer = BELOW_OBJ_LAYER
 	barricade = TRUE
 	proj_pass_rate = 65
+	drag_delay = 0.8 SECONDS
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's
 	var/secure = FALSE //secure locker or not, also used if overriding a non-secure locker with a secure door overlay to add fancy lights

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -12,6 +12,7 @@
 	material_drop = /obj/item/stack/sheet/cloth
 	delivery_icon = null //unwrappable
 	anchorable = FALSE
+	drag_delay = 0.1 SECONDS
 	var/foldedbag_path = /obj/item/bodybag
 	var/tagged = 0 // so closet code knows to put the tag overlay back
 
@@ -37,6 +38,12 @@
 		name = "body bag"
 		tagged = 0
 		update_icon()
+
+/obj/structure/closet/body_bag/take_contents()
+	var/atom/L = drop_location()
+	for(var/mob/living/body in L)
+		if(insert(body) == -1) // limit reached
+			break
 
 /obj/structure/closet/body_bag/update_icon()
 	..()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -208,6 +208,8 @@
 		step(AM, t)
 		if(current_dir)
 			AM.setDir(current_dir)
+		if(client && AM.drag_delay)
+			client.move_delay += AM.drag_delay
 		now_pushing = 0
 
 /mob/living/start_pulling(atom/movable/AM, supress_message = 0)
@@ -543,6 +545,8 @@
 				. += config_run_delay.value_cache
 			if(MOVE_INTENT_WALK)
 				. += config_walk_delay.value_cache
+		if(pulling?.drag_delay)
+			. += pulling.drag_delay
 
 /mob/living/proc/makeTrail(turf/target_turf, turf/start, direction)
 	if(!has_gravity())

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -929,3 +929,11 @@
 
 	var/datum/language_holder/H = get_language_holder()
 	H.open_language_menu(usr)
+
+/mob/Move_Pulled(atom/A)
+	var/pulling_delay = pulling.drag_delay
+	. = ..()
+	if(!.)
+		return
+	if(client && pulling_delay)
+		client.move_delay += pulling_delay

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -8,6 +8,7 @@
 	pressure_resistance = 8
 	mouse_drag_pointer = MOUSE_ACTIVE_POINTER
 	throwforce = 10
+	drag_delay = 0.1 SECONDS
 	var/lighting_alpha = LIGHTING_PLANE_ALPHA_VISIBLE
 	var/datum/mind/mind
 	var/list/datum/action/actions = list()


### PR DESCRIPTION
Moving while pulling, pushing and moving through clicking while pulling all cause a movement delay on the user.

Lockers have the highest delay, 0.8 seconds.
Undefined structures and machines the second, 0.6. This might need tweaking for things that need lower delays.
Small items, rolling chairs, bodybags and people have the lowest delay, 0.1. It's noticeable and someone giving chase will likely catch up to them.
Rolling beds have no wield delay.
Other undefined things, including large weapons, have a drag delay of 0.3, which is very non-viable in combat.

Bodybags only accept mobs for contents now, to avoid using them as a low-slowdown object carrier.