### PR TITLE
Update wasteland.dm

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -304,10 +304,8 @@ Wastelander
 		/obj/item/reagent_containers/pill/radx=1, \
 		/obj/item/storage/bag/money/small/wastelander)
 	suit_store = pick(
-	/obj/item/gun/ballistic/revolver/detective, \
-	/obj/item/gun/ballistic/shotgun/remington, \
-	/obj/item/gun/ballistic/revolver/zipgun, \
-	/obj/item/gun/ballistic/revolver/pipe_rifle)
+	/obj/item/gun/ballistic/automatic/pistol/ninemil, \
+	/obj/item/gun/ballistic/automatic/pistol/n99)
 	
 /datum/outfit/loadout/vault_refugee
 	name = "Vaultie"


### PR DESCRIPTION
Increasing the survival rate of wasters from spawn by giving them one handed, common weapons in case they get cornered with the loadout in hand and don't have the mind to simply beat a fool to death. Both the guns added do the exact same damage with negligible armour pen from the 10mil.