### PR TITLE
Give ghouls NOBREATH 

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -4,7 +4,7 @@
 	say_mod = "rasps"
 	limbs_id = "ghoul"
 	species_traits = list(HAIR,FACEHAIR)
-	inherent_traits = list(TRAIT_RADIMMUNE)
+	inherent_traits = list(TRAIT_RADIMMUNE, TRAIT_NOBREATH)
 	inherent_biotypes = list(MOB_INORGANIC, MOB_HUMANOID)
 	punchstunthreshold = 9
 	use_skintones = 0


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Gives ghouls NOBREATH, meaning they no longer are effected by gases or require the ability to breath. When in CRIT it causes brute damage over time rather then oxygen.

## Motivation and Context
Ghouls in fallout new vegas have been shown to endure horrible conditions most humans wouldn't last in. Namely not needing food, water, or air for extended periods of time, such as Coffin Willie and that one boy from Fallout 4. Because of that I feel they should have this trait.

## How Has This Been Tested?
This was something that was already in code for other ss13 races that currently aren't in use. Because of that my testing was simply spawning in some ghouls and beating them into crit with a bumper sword, and scanning their health to make sure it worked.

## Changelog (necessary)
:cl:
tweak: Gave ghouls NOBREATH
/:cl:
