### PR TITLE
Change the recipes for Unstable FEV and FEV solutionic agar

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -133,7 +133,7 @@
 	name = "FEV solutionic agar"
 	id = "FEV_solutionvirusfood"
 	results = list("FEV_solutionvirusfood" = 1)
-	required_reagents = list("FEV_solution" = 1, "virusfood" = 1)
+	required_reagents = list("FEV_solution" = 1, "virusfood" = 1, "sugar" = 1)
 
 /datum/chemical_reaction/virus_food_synaptizine
 	name = "virus rations"

--- a/code/modules/reagents/chemistry/recipes/toxins.dm
+++ b/code/modules/reagents/chemistry/recipes/toxins.dm
@@ -49,8 +49,8 @@
 	name = "Unstable FEV solution"
 	id = "FEV_solution"
 	results = list("FEV_solution" = 5)
-	required_reagents = list("radium" = 1, "phosphorus" = 1, "chlorine" = 1, "virusfood" = 1)
-
+	required_reagents = list("radium" = 1, "phosphorus" = 1, "chlorine" = 1, "virusfood" = 2)
+	
 /datum/chemical_reaction/lexorin
 	name = "Lexorin"
 	id = "lexorin"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
I tweaked the recipes for both chemicals. FEV Solutionic agar requires Unstable FEV and Virus food to create, because of this when trying to make Unstable FEV, if you try and make more then 5 units at a time it'll start converting it to the agar instead, meaning if you don't make the Unstable FEV in batches of 5 at a time you end up LOSING more then your making. So for the Agar I added one part sugar in its place to prevent this from happening, and to balance out mass production I changed the Virus Food requirement in the Unstable FEV to 2 instead of 1.

## Motivation and Context
Making FEV isn't difficult it's just tedious to do, so this makes it a bit easier while still keeping people from mass-producing it.

## How Has This Been Tested?
I spawned in a debug chem synthesizer, dispenced all the reagents, then combined them to see if the recipes worked properly.

## Changelog (necessary)
:cl:
tweak: changed recipes for Unstable FEV and FEV Solutionic Agar to make acquiring FEV less tedious and slow while still keeping its production relatively low. 
/:cl:
