### PR TITLE
Remove FEV from ghoul meat, and adds radium to ghoul and centaur meats

### DIFF
--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -192,7 +192,7 @@
 	name = "ghoul meat"
 	icon_state = "flymeat"
 	desc = "Nothing says tasty like necrotic, radioactive mutant flesh"
-	list_reagents = list("nutriment" = 3, "uranium" = 3, "bad_food" = 2, "FEV_solution" = 1)
+	list_reagents = list("nutriment" = 3, "radium" = 6, "bad_food" = 2)
 	filling_color = "#FA8072"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/ghoul
 	slice_path = null
@@ -201,7 +201,7 @@
 	name = "ghoul steak"
 	desc = "Why would you even cook this?"
 	list_reagents = list("nutriment" = 4)
-	bonus_reagents = list("uranium" = 3)
+	bonus_reagents = list("radium" = 3)
 
 /obj/item/reagent_containers/food/snacks/meat/slab/gecko
 	name = "gecko meat"
@@ -239,7 +239,7 @@
 	name = "centaur meat"
 	icon_state = "flymeat"
 	desc = "Absolutely disgusting"
-	list_reagents = list("nutriment" = 3, "uranium" = 3, "bad_food" = 4, "FEV_solution" = 6)
+	list_reagents = list("nutriment" = 3, "radium" = 10, "bad_food" = 4, "FEV_solution" = 6)
 	filling_color = "#FA8072"
 	cooked_type = /obj/item/reagent_containers/food/snacks/meat/steak/centaur
 	slice_path = null
@@ -248,7 +248,7 @@
 	name = "centaur steak"
 	desc = "No matter how much you cook, it doesn't seem safe to eat."
 	list_reagents = list("nutriment" = 4)
-	bonus_reagents = list("uranium" = 3, "FEV_solution" = 6)
+	bonus_reagents = list("radium" = 5, "FEV_solution" = 6)
 
 
 ////////////////////////////////////// OTHER MEATS ////////////////////////////////////////////////////////


### PR DESCRIPTION
## Description
Removes FEV from ghous, since there's no evidence they're infect with it at all (sorry farmers), and adds radium to ghoul and centaur meats, making ghouls an 'viable' source of food if eaten in small quantities, and ceanturs even more toxic that already was (seriously don't eat it).

## Motivation and Context
See images below:
![image](https://user-images.githubusercontent.com/46802162/72223369-bba28b80-354c-11ea-9dc9-5748f183f14b.png)
![image](https://user-images.githubusercontent.com/46802162/72223371-bf361280-354c-11ea-8118-b51897287baf.png)

## How Has This Been Tested?
Tested in local server.

## Changelog (necessary)
:cl:
tweak: removes FEV form ghoul meat
tweak: add radium to ghoul and centaur meats
/:cl:
