### PR TITLE
Update ghoul.dm

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -24,6 +24,12 @@
 	for(var/obj/item/bodypart/b in C.bodyparts)
 		b.max_damage = initial(b.max_damage)
 
+/datum/species/ghoul/qualifies_for_rank(rank, list/features)
+	if(rank in GLOB.legion_positions) /* legion HATES these ghoul */
+		return 0
+	if(rank in GLOB.brotherhood_positions) //don't hate them, just tolorate. 
+		return 0
+	return ..()
 
 /*/datum/species/ghoul/glowing
 	name = "Glowing Ghoul"

--- a/code/modules/mob/living/carbon/human/species_types/ghoul.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ghoul.dm
@@ -29,6 +29,8 @@
 		return 0
 	if(rank in GLOB.brotherhood_positions) //don't hate them, just tolorate. 
 		return 0
+	if(rank in GLOB.vault_positions) //purest humans left in america. supposedly.
+		return 0
 	return ..()
 
 /*/datum/species/ghoul/glowing


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Sets it so people can't midround join, or start as a ghoul for the legion or BoS. 

## Motivation and Context
Legion hates ghouls and won't accept them into their ranks. Bos tolerate ghouls, but won't allow them into their ranks for the most part.

## How Has This Been Tested?
Tried spawning in as  a ghouls for legion and BoS roles, set me to human by default


## Changelog (necessary)
:cl:
ADD: Lore friendly shinanigains.
/:cl:
