### PR TITLE
Autolathe fix

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -460,5 +460,7 @@
 	if("Security" in D.category)
 		if(DRM == 1)
 			return FALSE
+		else
+			. = ..()
 	else
 		. = ..()


### PR DESCRIPTION
turns out the fix to the exploit made it not work, so here we go!

:cl:
fix: Fixes a bug with the constructionlathe DRM.
/:cl:
