### PR TITLE
Adds new staff role

### DIFF
--- a/config/admin_ranks.txt
+++ b/config/admin_ranks.txt
@@ -35,24 +35,25 @@
 # END_KEYWORDS
 
 #Previous ranks on archive incase someone shits the proverbial bed. (once everyone has been switched over to the new ranks you're more than welcome to blitz these to reduce bloat)
-Admin Observer	= -AUTOLOGIN
+Admin Observer		= -AUTOLOGIN
 Moderator		= +ADMIN +FUN +BAN +SPAWN +POSSESS +BUILD +VAREDIT
-Admin Candidate	= +@
+Admin Candidate		= +@
 Trial Admin		= +@ +SPAWN +VAREDIT +BAN
-Mentor		= +ADMIN
+Devmentor		= +@ +SERVER +DEBUG -AUTOLOGIN
+Mentor			= +ADMIN
 Badmin			= +@ +POSSESS +POLL +BUILDMODE +SERVER +FUN
 Admin			= +EVERYTHING *EVERYTHING
 Game Master		= +EVERYTHING *EVERYTHING
-Lazy Master 	= +EVERYTHING -AUTOLOGIN *EVERYTHING
+Lazy Master 		= +EVERYTHING -AUTOLOGIN *EVERYTHING
 Three Dog		= -@ -ADMIN +DJ
 Scribe 			= +SERVER +DEBUG +VAREDIT +SPAWN -AUTOLOGIN
-Head Scribe 	= +@ +POLL -AUTOLOGIN
+Head Scribe 		= +@ +POLL -AUTOLOGIN
 Initiate		= +ADMIN
 Aspirant 		= +@ +BAN
 Knight 			= +@ +SPAWN +FUN +VAREDIT
 Paladin			= +@ +STEALTH +POSSESS +BUILD +SOUND +SERVER +DEBUG
 Head Coder 		= +EVERYTHING *EVERYTHING
-Head Paladin	= +EVERYTHING *EVERYTHING
+Head Paladin		= +EVERYTHING *EVERYTHING
 Elder			= +EVERYTHING *EVERYTHING
 Host 			= +EVERYTHING *EVERYTHING
-Supporter	= +AUTOLOGIN
+Supporter		= +AUTOLOGIN


### PR DESCRIPTION
Adds a new st... yeah, just read the changelog. Now mentors can be promoted to developer roles without losing their +ADMIN buttons.

Moderator has: +ADMIN +FUN +BAN +SPAWN +POSSESS +BUILD +VAREDIT
Scribe has: +SERVER +DEBUG +VAREDIT +SPAWN -AUTOLOGIN
Devmentor has all of the above. Name subject to change.

:cl:
admin: Adds a new staff role lovingly titled 'Devmentor'. Combined perms of a Moderator + Scribe (Developer).
/:cl:
