### PR TITLE
updates and fixes for flavor_text

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1380,7 +1380,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("flavor_text")
 					var/oldtext = features["flavor_text"]
-					var/msg = stripped_multiline_input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes. \n To delete flavor text, input a space and hit 'OK'.","Flavor Text",html_decode(features["flavor_text"]), MAX_MESSAGE_LEN*2, TRUE) as null|message
+					var/msg = stripped_multiline_input(usr," Set the flavor text in your 'examine' verb. This can also be used for OOC notes. \n Leave blank and hit 'OK' to delete it. Hit 'Cancel' to abort. \n This will not be visible if you wear a mask or helmet that hides your face.","Flavor Text",html_decode(features["flavor_text"]), MAX_MESSAGE_LEN*2, TRUE) as null|message
 					if(msg)
 						msg = copytext(msg, 1, MAX_MESSAGE_LEN*2)
 						features["flavor_text"] = msg
@@ -1861,46 +1861,3 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			return
 		else
 			custom_names[name_id] = sanitized_name
-//////////////////////////////////////////////////////
-////////////////////SUBTLE COMMAND////////////////////
-//////////////////////////////////////////////////////
-/mob
-	var/flavor_text = "" //tired of fucking double checking this
-
-/mob/proc/update_flavor_text()
-	set src in usr
-	if(usr != src)
-		to_chat(usr, "No.")
-	var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", html_decode(flavor_text), MAX_MESSAGE_LEN*2, TRUE)
-
-	if(!isnull(msg))
-		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
-		msg = html_encode(msg)
-
-		flavor_text = msg
-
-/mob/proc/warn_flavor_changed()
-	if(flavor_text && flavor_text != "") // don't spam people that don't use it!
-		to_chat(src, "<h2 class='alert'>OOC Warning:</h2>")
-		to_chat(src, "<span class='alert'>Your flavor text is likely out of date! <a href='?src=[REF(src)];flavor_change=1'>Change</a></span>")
-
-/mob/proc/print_flavor_text()
-	if(flavor_text && flavor_text != "")
-		// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
-		var/msg = html_decode(replacetext(flavor_text, "\n", " "))
-		if(length(msg) <= 40)
-			return "<span class='notice'>[html_encode(msg)]</span>"
-		else
-			return "<span class='notice'>[html_encode(copytext(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
-
-/mob/proc/get_top_level_mob()
-	if(istype(src.loc,/mob)&&src.loc!=src)
-		var/mob/M=src.loc
-		return M.get_top_level_mob()
-	return src
-
-proc/get_top_level_mob(var/mob/S)
-	if(istype(S.loc,/mob)&&S.loc!=S)
-		var/mob/M=S.loc
-		return M.get_top_level_mob()
-	return S

--- a/code/modules/mob/flavor_text.dm
+++ b/code/modules/mob/flavor_text.dm
@@ -1,0 +1,34 @@
+/*
+basically Baystation's character flavor text edited to work with /tg/ code.
+
+flavor_text is loaded and saved for player savegames as part of DNA, in
+	code\modules\client\preferences.dm
+and can only be edited by players during character setup, in
+	code\modules\client\preferences_savefile.dm
+
+it is transfered from DNA to human mobs (on a carbon mob level) in
+	code\datums\dna.dm
+whenever needed.
+
+the two main player-facing functionalities are:
+	A) adding a short (with Topic-link) version of the text to human examine() output, in
+		code\modules\mob\living\carbon\human\examine.dm
+
+	B) showing the full text in a window via human Topic() call, in
+		code\modules\mob\living\carbon\human\human.dm
+
+in general these two functionalities could be added to any kind of mob's examine() and Topic(),
+you would need to add a way (e.g. verb) for the mobs to set the text as they do not have access to the character setup screen,
+but I am not sure you even want non-humans to have it (not even Bay does that), so no tragic backstory for cleanbots for now.
+*/
+
+/mob/var/flavor_text = ""
+
+/mob/proc/print_flavor_text()
+	if(flavor_text && flavor_text != "")
+		// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
+		var/msg = html_decode(replacetext(flavor_text, "\n", " "))
+		if(length(msg) <= 40)
+			return "<span class='notice'>[html_encode(msg)]</span>"
+		else
+			return "<span class='notice'>[html_encode(copytext(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -218,6 +218,12 @@
 
 
 /mob/living/carbon/human/Topic(href, href_list)
+
+	if(href_list["flavor_more"])
+		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
+		onclose(usr, "[name]")
+		return
+
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
 		if(href_list["embedded_object"])
 			var/obj/item/bodypart/L = locate(href_list["embedded_limb"]) in bodyparts
@@ -744,7 +750,7 @@
 	if(!Adjacent(M) && (M.loc != src))
 		if((be_close == 0) || (dna.check_mutation(TK) && tkMaxRangeCheck(src, M)))
 			return TRUE
-		to_chat(src, "<span class='warning'>You are too far away!</span>") //Bug: this is preventing flavor text from being seen except when adjacent. See print_flavor_text() in preferences.dm
+		to_chat(src, "<span class='warning'>You are too far away!</span>")
 		return FALSE
 	return TRUE
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -463,13 +463,6 @@
 		unset_machine()
 		src << browse(null, t1)
 
-	if(href_list["flavor_more"])
-		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text, "\n", "<BR>")), text("window=[];size=500x200", name))
-		onclose(usr, "[name]")
-
-	if(href_list["flavor_change"])
-		update_flavor_text()
-
 	if(href_list["refresh"])
 		if(machine && in_range(src, usr))
 			show_inv(machine)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1894,6 +1894,7 @@
 #include "code\modules\mining\lavaland\ruins\gym.dm"
 #include "code\modules\mob\death.dm"
 #include "code\modules\mob\emote.dm"
+#include "code\modules\mob\flavor_text.dm"
 #include "code\modules\mob\inventory.dm"
 #include "code\modules\mob\login.dm"
 #include "code\modules\mob\logout.dm"


### PR DESCRIPTION
an updated and fixed version of @SpaceVampire's addition of Baystation's character flavor text to work with /tg/ code,
props to him for laying the groundwork.

done in this commit:
- removed unused and unneeded parts left over from Bay's version to reduce clutter
- fixed the proximity bug as described in https://github.com/judgex/desertrose/issues/77#issue-560163156
- added an explanation of the implementation for future generations who might want to add tragic backstories to non-humans