### PR TITLE
Great Khan helmet spawn fix and minor buff

### DIFF
--- a/code/modules/clothing/suits/f13.dm
+++ b/code/modules/clothing/suits/f13.dm
@@ -175,7 +175,7 @@
 	icon_state = "khan"
 	item_state = "jensencoat"
 	body_parts_covered = CHEST
-	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
+	armor = list(melee = 30, bullet = 30, laser = 20, energy = 20, bomb = 30, bio = 0, rad = 0, fire = 25, acid = 25)
 	allowed = list(/obj/item/pen,/obj/item/paper,/obj/item/stamp,/obj/item/reagent_containers/food/drinks/flask,/obj/item/weapon,/obj/item/storage/box/matches,/obj/item/lighter,/obj/item/clothing/mask/cigarette,/obj/item/storage/fancy/cigarettes,/obj/item/flashlight,/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
 
 /obj/item/clothing/suit/toggle/labcoat/f13/followers

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -79,7 +79,7 @@ Great Khan
 		/obj/item/gun/ballistic/revolver/caravan_shotgun, \
 		/obj/item/gun/ballistic/revolver/pipe_rifle, \
 		/obj/item/gun/ballistic/automatic/pistol/ninemil)
-	head = /obj/item/clothing/head/helmet/knight/f13/metal
+	head = /obj/item/clothing/head/helmet/f13/khan
 	shoes = /obj/item/clothing/shoes/f13/khan
 
 /datum/outfit/job/wasteland/f13pusher/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -60,7 +60,7 @@ Great Khan
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
 
-	suit = /obj/item/clothing/suit/armor/khan
+	suit = /obj/item/clothing/suit/toggle/labcoat/f13/khan
 	uniform = /obj/item/clothing/under/f13/khan
 
 /datum/outfit/job/wasteland/f13pusher/pre_equip(mob/living/carbon/human/H)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Making it so that the Great Khan role get their faction helmet instead of the metal helmet.
UPDATE: Also changed the Great Khans so that they spawn with a better armor

## Motivation and Context
Doesn't make sence for the Khans to now spawn with their helmet, but instead the kind you would see on any regular raiders.
For the armor changes it was because they had less damage resistance (such as bullet or melee damage) than normal raider armor, plus many people would abandon the armor most of the time.

## How Has This Been Tested?
Did it locally and it worked.

## Changelog (necessary)
:cl:
tweak: Great Khans now spawn with the correct helmet.
tweak: Great Khans armor value is changed to be more close to regular raider armor
tweak: Great Khans now spawn with an armor they can toggle as open or closed
/:cl:
