### PR TITLE
Adds craftable binoculars and reinforce-able machetes.  

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1007,6 +1007,15 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
 	category = CAT_MISC
 
+/datum/crafting_recipe/Binoculars
+	name = "Binoculars"
+	result = /obj/item/twohanded/binocs
+	time = 60
+	reqs = list(/obj/item/stack/sheet/steel = 10,
+				/obj/item/stack/sheet/glass = 5)
+	tools = list(TOOL_SCREWDRIVER,TOOL_WORKBENCH)
+	category = CAT_MISC
+
 /datum/crafting_recipe/spooky_camera
 	name = "Camera Obscura"
 	result = /obj/item/camera/spooky
@@ -1708,12 +1717,12 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/gladius
-	name = "Machete Gladius"
-	result = /obj/item/claymore/machete/gladius
+/datum/crafting_recipe/reinforcemachete
+	name = "Reinforce machete"
+	result = /obj/item/claymore/machete/reinforced
 	time = 80
-	reqs = list(/obj/item/stack/sheet/metal = 10,
-				/obj/item/stack/sheet/mineral/wood = 2)
+	reqs = list(/obj/item/stack/sheet/metal = 7,
+				/obj/item/claymore/machete = 1)
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1007,7 +1007,7 @@
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
 	category = CAT_MISC
 
-/datum/crafting_recipe/Binoculars
+/datum/crafting_recipe/binoculars
 	name = "Binoculars"
 	result = /obj/item/twohanded/binocs
 	time = 60

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1011,7 +1011,7 @@
 	name = "Binoculars"
 	result = /obj/item/twohanded/binocs
 	time = 60
-	reqs = list(/obj/item/stack/sheet/steel = 10,
+	reqs = list(/obj/item/stack/sheet/metal = 10,
 				/obj/item/stack/sheet/glass = 5)
 	tools = list(TOOL_SCREWDRIVER,TOOL_WORKBENCH)
 	category = CAT_MISC


### PR DESCRIPTION
## Description
Binoculars are now craft able the cost is 10 metal and 5 glass, Requires a screwdriver and workbench.
Machete gladius is no longer craftable.
Reinforced machete is now able to be crafted instead, costing 7 metal and a machete.
## Motivation and Context
The Machete gladius in my belief is a high quality weapon that should be seen mostly on legionaries who have earned it. The reinforced machete holds the same purpose and has the same amount of force the only downside being a minor 10 block lost.
Binoculars being craftable allows for more scouting an IC information to be gathered and they are not a extremely complex item. And also prevents people carrying a scoped rifle to be used solely for information gathering.
## How Has This Been Tested?
I created a private server and gathered the relevant materials and tools before crafting them using the crafting menu.

## Screenshots (if appropriate):
![CraftableBinoculars](https://user-images.githubusercontent.com/62524471/77285374-b8ecb100-6cc8-11ea-9ebb-d9bc67ffc323.png)
![Reinforcedmachete](https://user-images.githubusercontent.com/62524471/77285382-bdb16500-6cc8-11ea-8efe-9d64113bb31f.png)

## Changelog (necessary)
:cl:
CRAFTING MENU
add: Reinforced machete now craftable.
add: Binoculars now craftable.
del: Machete gladius no longer craftable.
/:cl:
