### PR TITLE
Rebalances Numerous Devices (RND)

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -382,8 +382,9 @@ SUBSYSTEM_DEF(job)
 			if(!AssignRole(player, SSjob.overflow_role))
 				RejectPlayer(player)
 	else if(player.client.prefs.joblessrole == BERANDOMJOB)
-		if(!GiveRandomJob(player))
-			RejectPlayer(player)
+/*		if(!GiveRandomJob(player))
+			RejectPlayer(player)*/
+		RejectPlayer(player) //Doesn't play nice with whitelists.
 	else if(player.client.prefs.joblessrole == RETURNTOLOBBY)
 		RejectPlayer(player)
 	else //Something gone wrong if we got here.

--- a/code/game/objects/items/powerfist.dm
+++ b/code/game/objects/items/powerfist.dm
@@ -21,7 +21,7 @@
 	desc = "A metal gauntlet with a piston-powered ram on top. This one has been painted in the colors of Caesar's Legion, and features a brutal metal spike to increase penetration and damage."
 	icon_state = "goliath"
 	force = 45 //you are Strongly Encouraged not to get hit by this.
-	armour_penetration = 65
+	armour_penetration = 100 //what is armor?
 	throwforce = 20
 
 /obj/item/gun/ballistic/revolver/ballisticfist //it's a double-barrel shotgun disguised as a fist shhh

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -299,6 +299,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("softcap", /obj/item/clothing/head/soft/mime, 2), \
 	new/datum/stack_recipe("beanie", /obj/item/clothing/head/beanie, 2), \
 	new/datum/stack_recipe("armband", /obj/item/clothing/accessory/armband/white, 1), \
+	new/datum/stack_recipe("black beret", /obj/item/clothing/head/HoS/beret/syndicate, 4), \
 	null, \
 	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/sunglasses/blindfold, 2), \
 	new/datum/stack_recipe("muzzle", /obj/item/clothing/mask/muzzle, 2), \

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -130,8 +130,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/job_enclave_med = 0
 	var/job_enclave_low = 0
 
-		// Want randomjob if preferences already filled - Donkie
-	var/joblessrole = BERANDOMJOB  //defaults to 1 for fewer assistants
+		// Return to lobby if preferences filled
+	var/joblessrole = RETURNTOLOBBY
 
 	// 0 = character settings, 1 = game preferences
 	var/current_tab = 0
@@ -785,9 +785,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		HTML += "</td'></tr></table>"
 		HTML += "</center></table>"
 
-		var/message = "Be an [SSjob.overflow_role] if preferences unavailable"
+		var/message = "Be a [SSjob.overflow_role] if preferences unavailable"
 		if(joblessrole == BERANDOMJOB)
-			message = "Get random job if preferences unavailable"
+			message = "Return to lobby if preferences unavailable" //Random job disabled
 		else if(joblessrole == RETURNTOLOBBY)
 			message = "Return to lobby if preferences unavailable"
 		HTML += "<center><br><a href='?_src_=prefs;preference=job;task=random'>[message]</a></center>"
@@ -1236,11 +1236,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				switch(joblessrole)
 					if(RETURNTOLOBBY)
 						if(jobban_isbanned(user, SSjob.overflow_role))
-							joblessrole = BERANDOMJOB
+							joblessrole = RETURNTOLOBBY
 						else
 							joblessrole = BEOVERFLOW
 					if(BEOVERFLOW)
-						joblessrole = BERANDOMJOB
+						joblessrole = RETURNTOLOBBY
 					if(BERANDOMJOB)
 						joblessrole = RETURNTOLOBBY
 				SetChoices(user)

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -45,7 +45,7 @@
 			log_admin("[key_name(src)] has attempted to advertise in OOC: [msg]")
 			message_admins("[key_name_admin(src)] has attempted to advertise in OOC: [msg]")
 			return
-		var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|spic|pedo|loli|shota", "i")
+		var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|pedo|loli|shota", "i")
 		if(findtext(msg, slurs))
 			to_chat(src, "<B>Slurs are not allowed on Desert Rose.</B>")
 			log_admin("[key_name(src)] has triggered the slur filter (OOC): [msg].")

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -387,7 +387,7 @@
 	desc = "A pre-war ceramic and kevlar helmet designed to absorb kinetic impacts and stop projectiles from entering the users skull. Has the words BORN TO KILL written on the outside in chalk."
 	icon_state = "combat_helmet"
 	item_state = "combat_helmet"
-	armor = list("melee" = 45, "bullet" = 30, "laser" = 30, "energy" = 60, "bomb" = 25, "bio" = 60, "rad" = 60, "fire" = 60, "acid" = 0)
+	armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
 	strip_delay = 50
 	flags_inv = HIDEEARS|HIDEHAIR
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
@@ -414,7 +414,7 @@
 	desc = "An advanced pre-war titanium plated, ceramic coated, kevlar, padded helmet designed to withstand extreme punishment of all forms."
 	icon_state = "combat_helmet_mk2"
 	item_state = "combat_helmet_mk2"
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = 39, "bio" = 70, "rad" = 70, "fire" = 70, "acid" = 0)
+	armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 40, "bomb" = 39, "bio" = 70, "rad" = 70, "fire" = 70, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/combat/mk2/dark
 	name = "reinforced combat helmet"
@@ -425,7 +425,7 @@
 	desc = "An improved combat helmet, seen commonly worn on initiates"
 	icon_state = "brotherhood_helmet"
 	item_state = "brotherhood_helmet"
-	armor = list("melee" = 60, "bullet" = 40, "laser" = 40, "energy" = 40, "bomb" = 39, "bio" = 70, "rad" = 70, "fire" = 70, "acid" = 0)
+	armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 40, "bomb" = 39, "bio" = 70, "rad" = 70, "fire" = 70, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/combat/enclave
 	name = "enclave combat helmet"
@@ -705,19 +705,19 @@
 		if(ismob(loc))
 			to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in helmet. Rerouting power to emergency systems.</span>")
 			tint += 2
-			if(iscarbon(loc))
-				var/mob/living/carbon/C = loc
-				C.head_update(src, forced = 1)
+			if(istype(loc, /mob/living/carbon))
+				var/mob/living/carbon/M = loc
+				M.update_tint()
 			armor = armor.modifyRating(melee = -20, bullet = -20, laser = -20)
 			emped = 1
-			sleep(50) //5 seconds of being blind and weak
-			to_chat(loc, "<span class='warning'>Helmet power reroute successful. All systems operational.</span>")
-			tint -= 2
-			if(iscarbon(loc))
-				var/mob/living/carbon/C = loc
-				C.head_update(src, forced = 1)
-			armor = armor.modifyRating(melee = 20, bullet = 20, laser = 20)
-			emped = 0
+			spawn(50) //5 seconds of being blind and weak
+				to_chat(loc, "<span class='warning'>Helmet power reroute successful. All systems operational.</span>")
+				tint -= 2
+				if(istype(loc, /mob/living/carbon))
+					var/mob/living/carbon/M = loc
+					M.update_tint()
+				armor = armor.modifyRating(melee = 20, bullet = 20, laser = 20)
+				emped = 0
 
 /obj/item/clothing/head/helmet/power_armor/t45b
 	name = "salvaged T-45b helmet"
@@ -733,14 +733,14 @@
 	desc = "It's an advanced power armor Mk I helmet, typically used by the Enclave. It looks somewhat threatening."
 	icon_state = "advhelmet1"
 	item_state = "advhelmet1"
-	armor = list("melee" = 90, "bullet" = 75, "laser" = 60, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 60, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/head/helmet/power_armor/advanced/mk2
 	name = "advanced power helmet MK2"
 	desc = "It's an improved model of advanced power armor used exclusively by the Enclave military forces, developed after the Great War.<br>Like its older brother, the standard advanced power armor, it's matte black with a menacing appearance, but with a few significant differences - it appears to be composed entirely of lightweight ceramic composites rather than the usual combination of metal and ceramic plates.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advhelmet2"
 	item_state = "advhelmet2"
-	armor = list("melee" = 95, "bullet" = 90, "laser" = 70, "energy" = 90, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 95, "bullet" = 95, "laser" = 70, "energy" = 90, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/head/helmet/power_armor/tesla
 	name = "tesla power helmet"
@@ -754,14 +754,14 @@
 	desc = "It's a T-51b power helmet, typically used by the Brotherhood. It looks somewhat charming."
 	icon_state = "t51bhelmet"
 	item_state = "t51bhelmet"
-	armor = list("melee" = 80, "bullet" = 70, "laser" = 50, "energy" = 70, "bomb" = 62, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 90, "bullet" = 85, "laser" = 50, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0)
 
 /obj/item/clothing/head/helmet/power_armor/t45d
 	name = "T-45d power helmet"
 	desc = "It's an old pre-War power armor helmet. It's pretty hot inside of it."
 	icon_state = "t45dhelmet"
 	item_state = "t45dhelmet"
-	armor = list("melee" = 75, "bullet" = 60, "laser" = 40, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 85, "bullet" = 80, "laser" = 40, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0)
 	var/brightness_on = 4 //luminosity when the light is on
 	var/on = 0
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -123,8 +123,8 @@
 	icon_state = "hosberetblack"
 
 /obj/item/clothing/head/HoS/beret/syndicate
-	name = "syndicate beret"
-	desc = "A black beret with thick armor padding inside. Stylish and robust."
+	name = "black beret"
+	desc = "A black beret with thin armor padding inside. Stylish and robust."
 
 /obj/item/clothing/head/warden
 	name = "warden's police hat"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -536,7 +536,7 @@
 	desc = "A superior combat armor set made by the Brotherhood of Steel, standard issue for all initiates."
 	icon_state = "brotherhood_armor"
 	item_state = "brotherhood_armor"
-	armor = list("melee" = 60, "bullet" = 55, "laser" = 50, "energy" = 70, "bomb" = 60, "bio" = 70, "rad" = 70, "fire" = 70, "acid" = 40)
+	armor = list("melee" = 45, "bullet" = 50, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 60, "rad" = 15, "fire" = 60, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/combat/enclave
 	name = "enclave combat armor"
@@ -641,6 +641,7 @@
 	item_flags = SLOWS_WHILE_IN_HAND
 	clothing_flags = THICKMATERIAL
 	strip_delay = 200
+	equip_delay_self = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/clothing/suit/armor/f13/brokenpa/t45b
@@ -659,15 +660,18 @@
 
 /obj/item/clothing/suit/armor/f13/power_armor
 	w_class = WEIGHT_CLASS_HUGE
-	slowdown = 0.75
-	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
+	slowdown = 0.4 //+0.1 from helmet = total 0.5
+	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
-	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS
+	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	flags_inv = HIDEJUMPSUIT
 	item_flags = SLOWS_WHILE_IN_HAND
 	clothing_flags = THICKMATERIAL
+	equip_delay_self = 50
+	equip_delay_other = 60
 	strip_delay = 200
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	var/emped = 0
 
 /obj/item/clothing/suit/armor/f13/power_armor/mob_can_equip(mob/user, mob/equipper, slot, disable_warning = 1)
 	var/mob/living/carbon/human/H = user
@@ -679,7 +683,7 @@
 	if(slot == SLOT_WEAR_SUIT)
 		H.add_trait(TRAIT_STUNIMMUNE)
 		H.add_trait(TRAIT_PUSHIMMUNE)
-		return TRUE
+		return ..()
 
 /obj/item/clothing/suit/armor/f13/power_armor/dropped(mob/user)
 	var/mob/living/carbon/human/H = user
@@ -687,33 +691,50 @@
 	H.remove_trait(TRAIT_PUSHIMMUNE)
 	return ..()
 
+/obj/item/clothing/suit/armor/f13/power_armor/emp_act(mob/living/carbon/human/owner, severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(emped == 0)
+		if(ismob(loc))
+			to_chat(loc, "<span class='warning'>Warning: electromagnetic surge detected in armor. Rerouting power to emergency systems.</span>")
+			slowdown += 15
+			armor = armor.modifyRating(melee = -20, bullet = -20, laser = -20)
+			emped = 1
+			sleep(50) //5 seconds of being slow and weak
+			to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
+			slowdown -= 15
+			armor = armor.modifyRating(melee = 20, bullet = 20, laser = 20)
+			emped = 0
+
 /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	name = "T-45d power armor"
 	desc = "Originally developed and manufactured for the United States Army by American defense contractor West Tek, the T-45d power armor was the first version of power armor to be successfully deployed in battle."
 	icon_state = "t45dpowerarmor"
 	item_state = "t45dpowerarmor"
-	armor = list("melee" = 75, "bullet" = 60, "laser" = 40, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 85, "bullet" = 80, "laser" = 40, "energy" = 60, "bomb" = 62, "bio" = 100, "rad" = 90, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b
 	name = "T-51b power armor"
 	desc = "The pinnacle of pre-war technology. This suit of power armor provides substantial protection to the wearer."
 	icon_state = "t51bpowerarmor"
 	item_state = "t51bpowerarmor"
-	armor = list("melee" = 80, "bullet" = 70, "laser" = 50, "energy" = 70, "bomb" = 62, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	slowdown = 0.15 //+0.1 from helmet = total 0.25
+	armor = list("melee" = 90, "bullet" = 85, "laser" = 50, "energy" = 70, "bomb" = 82, "bio" = 100, "rad" = 100, "fire" = 95, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/t51b/sierra
 	name = "sierra power armor"
 	desc = "A captured set of T-51b power armor put into use by the NCR, it's been heavily modified and decorated with the head of a bear and intricate gold trimming. A two headed bear is scorched into the breastplate."
 	icon_state = "sierra"
 	item_state = "sierra"
-	armor = list("melee" = 90, "bullet" = 80, "laser" = 70, "energy" = 70, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced
 	name = "advanced power armor"
 	desc = "An advanced suit of armor typically used by the Enclave.<br>It is composed of lightweight metal alloys, reinforced with ceramic castings at key stress points.<br>Additionally, like the T-51b power armor, it includes a recycling system that can convert human waste into drinkable water, and an air conditioning system for it's user's comfort."
 	icon_state = "advpowerarmor1"
 	item_state = "advpowerarmor1"
-	armor = list("melee" = 90, "bullet" = 75, "laser" = 60, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 90, "bullet" = 90, "laser" = 60, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	equip_delay_self = 50
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced/mk2
 	name = "advanced power armor mark II"
@@ -721,7 +742,7 @@
 	icon_state = "advpowerarmor2"
 	item_state = "advpowerarmor2"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-	armor = list("melee" = 95, "bullet" = 90, "laser" = 70, "energy" = 90, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
+	armor = list("melee" = 95, "bullet" = 95, "laser" = 70, "energy" = 90, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/power_armor/tesla
 	name = "tesla power armor"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -701,11 +701,11 @@
 			slowdown += 15
 			armor = armor.modifyRating(melee = -20, bullet = -20, laser = -20)
 			emped = 1
-			sleep(50) //5 seconds of being slow and weak
-			to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
-			slowdown -= 15
-			armor = armor.modifyRating(melee = 20, bullet = 20, laser = 20)
-			emped = 0
+			spawn(50) //5 seconds of being slow and weak
+				to_chat(loc, "<span class='warning'>Armor power reroute successful. All systems operational.</span>")
+				slowdown -= 15
+				armor = armor.modifyRating(melee = 20, bullet = 20, laser = 20)
+				emped = 0
 
 /obj/item/clothing/suit/armor/f13/power_armor/t45d
 	name = "T-45d power armor"
@@ -734,7 +734,6 @@
 	icon_state = "advpowerarmor1"
 	item_state = "advpowerarmor1"
 	armor = list("melee" = 90, "bullet" = 90, "laser" = 60, "energy" = 75, "bomb" = 72, "bio" = 100, "rad" = 100, "fire" = 90, "acid" = 0)
-	equip_delay_self = 50
 
 /obj/item/clothing/suit/armor/f13/power_armor/advanced/mk2
 	name = "advanced power armor mark II"

--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -34,9 +34,9 @@
 	var/creator // circuit creator if any
 	var/static/next_assembly_id = 0
 	hud_possible = list(DIAG_STAT_HUD, DIAG_BATT_HUD, DIAG_TRACK_HUD, DIAG_CIRCUIT_HUD) //diagnostic hud overlays
-	max_integrity = 50
+	max_integrity = 40 //one decent .308 shot
 	pass_flags = 0
-	armor = list("melee" = 50, "bullet" = 70, "laser" = 70, "energy" = 100, "bomb" = 10, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
 	anchored = FALSE
 	var/can_anchor = TRUE
 	var/detail_color = COLOR_ASSEMBLY_BLACK

--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -277,6 +277,7 @@ Vexillarius
 	name = "Legion Vexillarius"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13vexillarius
 	id = 			/obj/item/card/id/dogtag/legveteran
+	mask =			/obj/item/clothing/mask/bandana/legvet
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/vet/vexil
 	head = 			/obj/item/clothing/head/helmet/f13/legion/vet/vexil
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
@@ -318,6 +319,7 @@ Legionary
 	name = "Legionary"
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13legionary
 	id = 			/obj/item/card/id/dogtag/legveteran
+	mask =			/obj/item/clothing/mask/bandana/legvet
 	suit = 			/obj/item/clothing/suit/armor/f13/legion/vet
 	head = 			/obj/item/clothing/head/helmet/f13/legion/vet
 	glasses = 		/obj/item/clothing/glasses/sunglasses

--- a/code/modules/mob/living/emote.dm
+++ b/code/modules/mob/living/emote.dm
@@ -429,7 +429,7 @@
 				else
 					alert("Unable to use this emote, must be either hearable or visible.")
 					return
-			var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|spic|pedo|loli|shota", "i")
+			var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|pedo|loli|shota", "i")
 			if(findtext(custom_emote, slurs))
 				//to_chat(user, "<B>Slurs are not allowed on Desert Rose.</B>")
 				log_admin("[key_name(user)] has triggered the slur filter in IC (emote): [custom_emote]")
@@ -437,7 +437,7 @@
 				//return 0 //Uncomment this (and the to_chat line) if we want to prevent them saying it, rather than just alert us.
 			message = custom_emote
 	else
-		var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|spic|pedo|loli|shota", "i")
+		var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|pedo|loli|shota", "i")
 		if(findtext(params, slurs))
 			//to_chat(user, "<B>Slurs are not allowed on Desert Rose.</B>")
 			log_admin("[key_name(user)] has triggered the slur filter in IC (emote): [params]")

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -297,7 +297,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			return 0
 		if(!ignore_spam && client.handle_spam_prevention(message,MUTE_IC))
 			return 0
-	var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|spic|pedo|loli|shota", "i")
+	var/static/regex/slurs = regex("nigg|fag|tranny|dyke|kike|pedo|loli|shota", "i")
 	if(findtext(message, slurs))
 		//to_chat(src, "<B>Slurs are not allowed on Desert Rose.</B>")
 		log_admin("[key_name(client)] has triggered the slur filter in IC (say): [message]")

--- a/code/modules/projectiles/guns/misc/medbeam.dm
+++ b/code/modules/projectiles/guns/misc/medbeam.dm
@@ -1,6 +1,6 @@
 /obj/item/gun/medbeam
 	name = "medical beamgun"
-	desc = "A rather advanced gun that can be used to heal something it targets, crossing the streams or not actively holding it will cause loss of control and deactive this tool."
+	desc = "A rather advanced gun that can be used to heal something it targets, albeit at the expense of causing minor blood toxicity. Not actively holding it will cause a loss of control and deactivate this tool."
 	icon = 'icons/obj/chronos.dmi'
 	icon_state = "chronogun"
 	item_state = "chronogun"
@@ -13,8 +13,6 @@
 	var/active = 0
 	var/datum/beam/current_beam = null
 	var/mounted = 0 //Denotes if this is a handheld or mounted version
-
-	weapon_weight = WEAPON_MEDIUM
 
 /obj/item/gun/medbeam/Initialize()
 	. = ..()
@@ -79,7 +77,7 @@
 		var/mob/living/carbon/human/user = loc
 		if(user.get_active_held_item() != src) //Can't use the medbeam if your active select hand doesn't contain it
 			LoseTarget()
-			to_chat(source, "<span class='warning'>Your grasp on the medbeam loosens when you were no longer focusing on it!!</span>")
+			to_chat(source, "<span class='warning'>Your grasp on the medbeam loosens when you stop actively focusing on it!</span>")
 
 	if(get_dist(source, current_target)>max_range || !los_check(source, current_target))
 		LoseTarget()
@@ -108,8 +106,6 @@
 			if(!AM.CanPass(dummy,turf,1))
 				qdel(dummy)
 				return 0
-		for(var/obj/effect/ebeam/medical/B in turf) //Crossing the beams now just disables the beam
-			return 0
 	qdel(dummy)
 	return 1
 
@@ -117,12 +113,17 @@
 	return
 
 /obj/item/gun/medbeam/proc/on_beam_tick(var/mob/living/target)
-	if(target.health != target.maxHealth)
+	if(target.getBruteLoss() != 0 || target.getFireLoss() != 0 || target.getOxyLoss() == 0) //Converts damage to toxins at a ratio of 4:1
 		new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
-	target.adjustBruteLoss(-4)
-	target.adjustFireLoss(-4)
-	target.adjustToxLoss(-1)
-	target.adjustOxyLoss(-1)
+	if(target.getBruteLoss() != 0)
+		target.adjustBruteLoss(-4)
+		target.adjustToxLoss(1)
+	if(target.getFireLoss() != 0)
+		target.adjustFireLoss(-4)
+		target.adjustToxLoss(1)
+	if(target.getOxyLoss() != 0)
+		target.adjustOxyLoss(-4)
+		target.adjustToxLoss(1)
 	return
 
 /obj/item/gun/medbeam/proc/on_beam_release(var/mob/living/target)

--- a/code/modules/projectiles/guns/misc/syringe_gun.dm
+++ b/code/modules/projectiles/guns/misc/syringe_gun.dm
@@ -112,4 +112,5 @@
 	item_state = "shotgun"
 	w_class = 4
 	zoomable = TRUE
-	zoom_amt = 7
+	zoom_amt = 10
+	zoom_out_amt = 13

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -41,11 +41,11 @@
 
 /obj/item/projectile/bullet/a50MG
 	damage = 60
-	armour_penetration = 20
+	armour_penetration = 60
 
 /obj/item/projectile/bullet/a50MG/incendiary
 	damage = 40
-	armour_penetration = 0
+	armour_penetration = 20
 	var/fire_stacks = 4
 
 /obj/item/projectile/bullet/a50MG/incendiary/on_hit(atom/target, blocked = FALSE)

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -107,7 +107,7 @@
 /datum/chemical_reaction/emp_pulse
 	name = "EMP Pulse"
 	id = "emp_pulse"
-	required_reagents = list("uranium" = 1, "iron" = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
+	required_reagents = list("uranium" = 1, "iron" = 1, "flash_powder" = 1) // Recipe changed from uranium/iron to uranium/iron/flashpowder. Remember to stabilize it.
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -87,7 +87,6 @@
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	amount_per_transfer_from_this = 10
 	volume = 10
-	ignore_flags = 1 //so you can medipen through hardsuits
 	container_type = DRAWABLE
 	flags_1 = null
 	list_reagents = list("epinephrine" = 10)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -27,7 +27,7 @@
 	display_name = "Advanced Biotechnology"
 	description = "Advanced Biotechnology"
 	prereq_ids = list("biotech")
-	design_ids = list("piercesyringe", "smoke_machine", "limbgrower", "defibrillator", "meta_beaker", "virusmaker")
+	design_ids = list("piercesyringe", "smoke_machine", "limbgrower", "defibrillator", "meta_beaker", "virusmaker", "medbeam")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	export_price = 5000
 
@@ -55,7 +55,7 @@
 	display_name = "Experimental Surgery"
 	description = "When evolution isn't fast enough."
 	prereq_ids = list("adv_surgery")
-	design_ids = list("surgery_pacify","surgery_vein_thread","surgery_nerve_splice","surgery_nerve_ground","surgery_viral_bond")
+	design_ids = list("surgery_revival", "surgery_pacify","surgery_vein_thread","surgery_nerve_splice","surgery_nerve_ground","surgery_viral_bond", "autosurgeon")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 5000
 

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -9,7 +9,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/obj/item/organ/storedorgan
 	var/organ_type = /obj/item/organ
-	var/uses = INFINITE
+	var/uses = 1
 	var/starting_organ
 
 /obj/item/autosurgeon/Initialize(mapload)
@@ -22,7 +22,7 @@
 	I.forceMove(src)
 	name = "[initial(name)] ([storedorgan.name])"
 
-/obj/item/autosurgeon/attack_self(mob/user)//when the object it used...
+/obj/item/autosurgeon/attack_self(mob/living/carbon/user)//when the object it used...
 	if(!uses)
 		to_chat(user, "<span class='warning'>[src] has already been used. The tools are dull and won't reactivate.</span>")
 		return
@@ -30,14 +30,16 @@
 		to_chat(user, "<span class='notice'>[src] currently has no implant stored.</span>")
 		return
 	storedorgan.Insert(user)//insert stored organ into the user
-	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='notice'>You feel a sharp sting as [src] plunges into your body.</span>")
+	user.visible_message("<span class='notice'>[user] presses a button on [src], and you hear a short mechanical noise.</span>", "<span class='warning'>You feel a brutally sharp pain as [src] plunges into your body!</span>")
 	playsound(get_turf(user), 'sound/weapons/circsawhit.ogg', 50, 1)
+	user.adjustBruteLoss(60) //ow, oof, ouch, owie
 	storedorgan = null
 	name = initial(name)
 	if(uses != INFINITE)
 		uses--
 	if(!uses)
-		desc = "[initial(desc)] Looks like it's been used up."
+		to_chat(user, "<span class='notice'>[src] collapses in on itself into a pile of scrap. It can't be used again.</span>")
+		qdel(src)
 
 /obj/item/autosurgeon/attack_self_tk(mob/user)
 	return //stops TK fuckery


### PR DESCRIPTION

- Possibly fixes the whitelist bug where you spawn as a role you don't have access to.
- Goliath powerfist (Centurions) now ignores all armor, not just most armor. Won't make a different except against power armor, which it's now very good against.
- You can craft a black beret with cloth.
- Power armor is a little faster than before (still slow) and _significantly_ more protective. It now takes a few seconds to put on, though, and has a crippling EMP vulnerability- for five seconds, their armor values drop, the helmet will blind you, and the armor will almost immobilize you. Additionally, stimpaks don't pierce them any more. Is it an overall nerf? Is it an overall buff? You decide.
- Fixes medbeam bug introduced in #144 . They actually work now. You still need to have it in your active hand. Oh, and they're in R&D again.
- Medbeams now convert brute, burn and oxy to toxin at a rate of 4:1.
- Integrated circuit drones no longer have armor, and have 40 health instead of 50.
- EMPs now require flash powder to mix. Have fun.
- Autosurgeons will deal significant damage when used, and destroy on use, but are available in R&D again.
- Revival disks are in R&D again.
- The word 'spicy!' will now no longer slap you.