### PR TITLE
Adds sugarcane to plant venders + Cook vender buffs

### DIFF
--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -13,6 +13,8 @@
 		            /obj/item/reagent_containers/food/condiment/pack/hotsauce = 5,
 		            /obj/item/reagent_containers/food/condiment/saltshaker = 5,
 		            /obj/item/reagent_containers/food/condiment/peppermill = 5,
+					/obj/item/reagent_containers/food/condiment/flour = 1,
+					/obj/item/reagent_containers/food/condiment/sugar = 1,
 		            /obj/item/reagent_containers/glass/bowl = 20)
 	contraband = list(/obj/item/kitchen/rollingpin = 2,
 		              /obj/item/kitchen/knife/butcher = 2)

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -32,6 +32,7 @@
 					/obj/item/seeds/pumpkin = 3,
 					/obj/item/seeds/wheat/rice = 3,
 					/obj/item/seeds/soya = 3,
+					/obj/item/seeds/sugarcane = 3,
 					/obj/item/seeds/sunflower = 3,
 					/obj/item/seeds/tea = 3,
 					/obj/item/seeds/tobacco = 3,


### PR DESCRIPTION

## Description
Adds sugarcane to plant venders - 3seeds
Adds a bottle of sugar to the cooking vender
Adds a bag of flour to the cooks vender

## Motivation and Context
Dellwers and other places that would use this vender can no start the round using any of the items inside, you need wheat to cook with the rolling pin limiting everything to meat. 

Flour and sugar almost never go bad if stored correctly so it logical that it could be stored inside the vender if we also say that the normal food is lasting that long as well
## How Has This Been Tested?
Nope
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: Sugar cane seeds have been added to seed venders
add: Sugar and some flour have been placed inside cooking venders
/:cl:
