### PR TITLE
Misleading sprite fix.

### DIFF
--- a/code/modules/hydroponics/grown/xander.dm
+++ b/code/modules/hydroponics/grown/xander.dm
@@ -8,7 +8,7 @@
 	lifespan = 25
 	endurance = 10
 	yield = 3 //6 //Where did you get 6 from???
-	growthstages = 3
+	growthstages = 4
 	production = 1
 	maturation = 1
 	growing_icon = 'icons/obj/hydroponics/growing_vegetables.dmi'


### PR DESCRIPTION
## Description
Increased the growth stage factor in xander to make it accurate.
## Motivation and Context
Fixes the shown sprite when the grown is planted.
## How Has This Been Tested?
Tested on a localhost in a clean compile. Sprite shown as expected.
## Changelog (necessary)
:cl:
tweak: Xander shows the correct sprite when planted.
/:cl:
