### PR TITLE
Fixes NPC runtime spam.

### DIFF
--- a/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
@@ -271,7 +271,7 @@
 	harm_intent_damage = 5
 	melee_damage_lower = 10
 	melee_damage_upper = 10
-	attacktext = "áüåò"
+	attacktext = "Ã¡Ã¼Ã¥Ã²"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	a_intent = INTENT_HARM
 	loot = list(/obj/effect/mob_spawn/human/corpse/bs)
@@ -365,7 +365,7 @@
 	harm_intent_damage = 5
 	melee_damage_lower = 10
 	melee_damage_upper = 10
-	attacktext = "áüåò"
+	attacktext = "Ã¡Ã¼Ã¥Ã²"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	a_intent = INTENT_HARM
 	loot = list(/obj/effect/mob_spawn/human/corpse/ncr)
@@ -411,7 +411,7 @@
 
 /mob/living/simple_animal/hostile/ncr/sergeant
 	name = "NCR Sergeant"
-	desc = "A sergeant for the New California Republic."
+	desc = "Just a NCR Sergeant"
 	icon_state = "ncr_sergeant"
 	icon_living = "ncr_sergeant"
 	icon_dead = "ncr_sergeant"

--- a/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
@@ -150,7 +150,7 @@
 	status_flags = CANPUSH
 	del_on_death = 1
 	speak = list("For the Enclave!", "Stars and Stripes!", "Liberty or death!")
-	speak_emote = "pulls out a weapon,"
+	speak_emote = list("pulls out a weapon", "shouts")
 	speak_chance = 0
 
 /obj/effect/mob_spawn/human/corpse/enclavescientist
@@ -282,7 +282,7 @@
 	status_flags = CANPUSH
 	del_on_death = 1
 	speak = list("Semper Invicta!")
-	speak_emote = "rushes."
+	speak_emote = list("rushes")
 	speak_chance = 1
 
 
@@ -346,7 +346,7 @@
 
 /mob/living/simple_animal/hostile/ncr
 	name = "NCR"
-	desc = "Just an NCR"
+	desc = "Just an NCR."
 	icon_state = "ncr_trooper"
 	icon_living = "ncr_trooper"
 	icon_dead = "ncr_trooper"
@@ -376,7 +376,7 @@
 	status_flags = CANPUSH
 	del_on_death = 1
 	speak = list("Patrolling the Mojave almost makes you wish for a nuclear winter.", "When I got this assignment I was hoping there would be more gambling.", "It's been a long tour, all I can think about now is going back home.", "You know, if you were serving, you'd probably be halfway to general by now.", "You oughtta think about enlisting. We need you here.")
-	speak_emote = "says,"
+	speak_emote = list("says")
 	speak_chance = 1
 
 
@@ -394,7 +394,7 @@
 
 /mob/living/simple_animal/hostile/ncr/trooper
 	name = "NCR Trooper"
-	desc = "Just a NCR Trooper"
+	desc = "A trooper for the New California Republic."
 	icon_state = "ncr_trooper"
 	icon_living = "ncr_trooper"
 	icon_dead = "ncr_trooper"
@@ -411,7 +411,7 @@
 
 /mob/living/simple_animal/hostile/ncr/sergeant
 	name = "NCR Sergeant"
-	desc = "Just a NCR Sergeant"
+	desc = "A sergeant for the New California Republic."
 	icon_state = "ncr_sergeant"
 	icon_living = "ncr_sergeant"
 	icon_dead = "ncr_sergeant"
@@ -471,7 +471,7 @@
 	status_flags = CANPUSH
 	del_on_death = 1
 	speak = list("Ave, true to Caesar.", "True to Caesar.", "Ave, Amicus.", "The new slave girls are quite beautiful.", "Give me cause, Profligate.", "Degenerates like you belong on a cross.")
-	speak_emote = "says,"
+	speak_emote = list("says")
 	speak_chance = 1
 
 /obj/effect/mob_spawn/human/corpse/legion
@@ -565,7 +565,7 @@
 	status_flags = CANPUSH
 	del_on_death = 1
 	speak = "Yes!"
-	speak_emote = "rushes"
+	speak_emote = list("rushes")
 	speak_chance = 2
 
 /obj/effect/mob_spawn/human/corpse/raider

--- a/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
+++ b/code/modules/fallout/mob/simple_animal/mobs/fallout_NPC.dm
@@ -394,7 +394,7 @@
 
 /mob/living/simple_animal/hostile/ncr/trooper
 	name = "NCR Trooper"
-	desc = "A trooper for the New California Republic."
+	desc = "Just a NCR Trooper"
 	icon_state = "ncr_trooper"
 	icon_living = "ncr_trooper"
 	icon_dead = "ncr_trooper"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue where NPCs with improperly set `speak_emote`s would cause massive runtime spams every time they spoke.

## Motivation and Context
It annoyed me when doing dev work.

## How Has This Been Tested?
N/A

## Changelog (necessary)
:cl:
fix: Fixed some NPCs causing runtime spam when they tried to speak when attacking.
/:cl:
