### PR TITLE
Removal of strange seeds.

### DIFF
--- a/code/modules/hydroponics/grown/random.dm
+++ b/code/modules/hydroponics/grown/random.dm
@@ -1,5 +1,5 @@
 //Random seeds; stats, traits, and plant type are randomized for each seed.
-
+/*
 /obj/item/seeds/random
 	name = "pack of strange seeds"
 	desc = "Mysterious seeds as strange as their name implies. Spooky."
@@ -33,3 +33,4 @@
 	wine_power = rand(10,150)
 	if(prob(1))
 		wine_power = 200
+*/


### PR DESCRIPTION
## Description
removal of strange seeds.

## Motivation and Context
Quoting forums user scarwolff
_"If Finding Mutation Toxins within Strange Seeds is Literally against the Rules, why are they still in the game? ... According to my good friend Doc_Possum, it breaks this rule ... So remove Mutation toxins from the code if using them are literally bannable. Also, it doesn't help that some players base their whole gameplay gimmick off of finding mutation toxins and literally nothing else just be muh Kwaii catgirl owoew."_
Quite frankly, I am apt to agree and it serves the same function of stimming the FEV problem that was an issue in the past.

## How Has This Been Tested?
N/A

## Changelog (necessary)
:cl:
del: commented out strange seeds
/:cl:
