### PR TITLE
[Ready] Fallout Clothing Var Sanity - Code cleaning/defencing 

### DIFF
--- a/code/modules/clothing/head/f13.dm
+++ b/code/modules/clothing/head/f13.dm
@@ -1,6 +1,7 @@
 //Fallout 13 protective helmets directory
 
 /obj/item/clothing/head/helmet/f13
+
 /obj/item/clothing/head/helmet/f13/tribal
 	name = "tribal power helmet"
 	desc = "This power armor helmet was salvaged by savages from the battlefield.<br>They believe that these helmets capture the spirits of their fallen wearers, so they painted some runes on to give it a more sacred meaning."

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -313,8 +313,6 @@
 	item_state = "arclight"
 	dynamic_hair_suffix = ""
 	visor_flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/raider/arclight/reinforced
 	name = "reinforced raider arclight helmet"
@@ -326,7 +324,6 @@
 	item_state = "blastmaster"
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/raider/blastmaster/reinforced
 	name = "reinforced raider blastmaster helmet"
@@ -337,8 +334,6 @@
 	desc = "Long time ago, it has belonged to a football player, now it belongs to wasteland."
 	icon_state = "yankee"
 	item_state = "yankee"
-	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE
 
 /obj/item/clothing/head/helmet/f13/raider/yankee/reinforced
@@ -368,7 +363,6 @@
 	icon_state = "psychotic"
 	item_state = "psychotic"
 	flags_cover = HEADCOVERSEYES
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEEYES|HIDEHAIR
 
 /obj/item/clothing/head/helmet/f13/raider/psychotic/reinforced
@@ -377,9 +371,6 @@
 	armor = list("melee" = 45, "bullet" = 30, "laser" = 20, "energy" = 5, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 
 //Combat armor
-/obj/item/clothing/head/helmet/f13
-	icon_state = "helmet"
-	item_state = "helmet"
 
 /obj/item/clothing/head/helmet/f13/combat
 	name = "combat helmet"
@@ -391,7 +382,6 @@
 	strip_delay = 50
 	flags_inv = HIDEEARS|HIDEHAIR
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
-	tint = 0
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 
@@ -501,7 +491,6 @@
 	desc = "It's a leather legion recruit helmet."
 	icon_state = "legrecruit"
 	item_state = "legrecruit"
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/head/helmet/f13/legion/recruit/scout
 	name = "legion scout hood"
@@ -604,7 +593,6 @@
 	armor = list("melee" = 75, "bullet" = 50, "laser" = 35, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 
-
 /obj/item/clothing/head/helmet/f13/legion/legate
 	name = "legion legate helmet"
 	desc = "A custom forged steel full helmet complete with abstract points and arches. The face is extremely intimidating, as it was meant to be. This particular one was ordered to be forged by Caesar, given to his second legate in exchange for his undying loyalty to Caesar."
@@ -624,7 +612,6 @@
 	armor = list("melee" = 60, "bullet" = 50, "laser" = 30, "energy" = 50, "bomb" = 39, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 0)
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEHAIR|HIDEFACIALHAIR|HIDEFACE
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-	strip_delay = 50
 	resistance_flags = LAVA_PROOF | FIRE_PROOF
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
@@ -659,13 +646,12 @@
 	desc = "A metal helmet, rusty and awful."
 	icon_state = "raidermetal"
 	item_state = "raidermetal"
-	can_toggle = 1
+	can_toggle = TRUE
 	armor = list("melee" = 50, "bullet" = 35, "laser" = 35, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 30, "fire" = 20, "acid" = 0)
 	flags_inv = HIDEMASK|HIDEEYES|HIDEFACE
 	strip_delay = 80
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	visor_flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
-
 
 /obj/item/clothing/head/helmet/f13/metalmask
 	name = "metal mask"
@@ -721,14 +707,13 @@
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	ispowerarmor = 1
+	ispowerarmor = 1 //TRUE
 	strip_delay = 200
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDEMASK
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	clothing_flags = THICKMATERIAL
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	flash_protect = 2
-	tint = 0
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 	speechspan = SPAN_ROBOT //makes you sound like a robot
@@ -756,7 +741,7 @@
 	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
 	heat_protection = HEAD
 	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
-	ispowerarmor = 1
+	ispowerarmor = 1 //TRUE
 	strip_delay = 200
 	equip_delay_self = 20
 	slowdown = 0.1
@@ -766,7 +751,6 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	item_flags = SLOWS_WHILE_IN_HAND
 	flash_protect = 2
-	tint = 0
 	dynamic_hair_suffix = ""
 	dynamic_fhair_suffix = ""
 	darkness_view = 128
@@ -879,8 +863,6 @@
 	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
 	dynamic_hair_suffix = ""
-
-
 
 //LightToggle
 

--- a/code/modules/clothing/head/ncr.dm
+++ b/code/modules/clothing/head/ncr.dm
@@ -49,7 +49,6 @@
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
 	strip_delay = 50
 
-
 /obj/item/clothing/head/f13/ncr/goggles/attack_self(mob/user)
 	if(can_toggle && !user.incapacitated())
 		if(world.time > cooldown + toggle_cooldown)

--- a/code/modules/clothing/masks/miscellaneous.dm
+++ b/code/modules/clothing/masks/miscellaneous.dm
@@ -249,8 +249,6 @@
 /obj/item/clothing/mask/bandana/attack_self(mob/user)
 	adjustmask(user)
 
-
-
 /obj/item/clothing/mask/bandana/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/wirecutters) || I.is_sharp())
 		var/obj/item/stack/sheet/cloth/C = new (get_turf(src), 2)
@@ -303,9 +301,7 @@
 	desc = "A fine recruit bandana."
 	icon_state = "legrecruit"
 	flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH
 	visor_flags_inv = HIDEFACE
-	visor_flags_cover = MASKCOVERSMOUTH
 	adjusted_flags = null
 	actions_types = list(/datum/action/item_action/adjust)
 
@@ -314,9 +310,7 @@
 	desc = "A fine decan bandana."
 	icon_state = "legdecan"
 	flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH
 	visor_flags_inv = HIDEFACE
-	visor_flags_cover = MASKCOVERSMOUTH
 	adjusted_flags = null
 	actions_types = list(/datum/action/item_action/adjust)
 
@@ -325,9 +319,7 @@
 	desc = "A fine centurion bandana."
 	icon_state = "legcenturion"
 	flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH
 	visor_flags_inv = HIDEFACE
-	visor_flags_cover = MASKCOVERSMOUTH
 	adjusted_flags = null
 	actions_types = list(/datum/action/item_action/adjust)
 
@@ -336,9 +328,7 @@
 	desc = "A fine veteran bandana."
 	icon_state = "legvet"
 	flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH
 	visor_flags_inv = HIDEFACE
-	visor_flags_cover = MASKCOVERSMOUTH
 	adjusted_flags = null
 	actions_types = list(/datum/action/item_action/adjust)
 
@@ -347,9 +337,7 @@
 	desc = "A fine prime bandana"
 	icon_state = "legdecan"
 	flags_inv = HIDEFACE
-	flags_cover = MASKCOVERSMOUTH
 	visor_flags_inv = HIDEFACE
-	visor_flags_cover = MASKCOVERSMOUTH
 	adjusted_flags = null
 	actions_types = list(/datum/action/item_action/adjust)
 
@@ -378,7 +366,6 @@
 	flags_cover = MASKCOVERSMOUTH
 	visor_flags_inv = HIDEFACE
 	visor_flags_cover = MASKCOVERSMOUTH
-
 
 //Society Mask
 

--- a/code/modules/clothing/shoes/f13.dm
+++ b/code/modules/clothing/shoes/f13.dm
@@ -95,28 +95,24 @@
 	desc = "A pair of standard issue NCR brown boots, with a puttee."
 	icon_state = "ncr_boots"
 	item_state = "ncr"
-	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/ncr_officer
 	name = "NCR officer boots"
 	desc = "A pair of calf high black, highly polished, leather boot that have been tightly laced. These definitely belong to a officer."
 	icon_state = "ncr_officer_boots"
 	item_state = "explorer"
-	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/ncr_scout
 	name = "NCR scout boots"
 	desc = "A pair of thick-soled leather boots, well-worn by the wearer."
 	icon_state = "scoutboots"
 	item_state = "scoutboots"
-	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/legionleather
 	name = "leather boots"
 	desc = "A pair of leather boots that appear to be mostly intact and lightly used. These belong to a Recruit Legionary of Caesar's Legion"
 	icon_state = "legionleather"
 	item_state = "legionleather"
-	armor = list(melee = 10, bullet = 10, laser = 0, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 
 /obj/item/clothing/shoes/f13/military/legionmetal
 	name = "plated metal boots"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -218,7 +218,6 @@
 	icon_state = "tdgreen"
 	item_state = "tdgreen"
 
-
 /obj/item/clothing/suit/armor/riot/knight
 	name = "plate armour"
 	desc = "A classic suit of plate armour, highly effective at stopping melee attacks."
@@ -415,7 +414,6 @@
 	item_state = "combat_armor"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/reconarmor
 	name = "recon armor"
@@ -424,7 +422,6 @@
 	item_state = "recon_armor"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 40, "bomb" = 50, "bio" = 60, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 	icon = 'icons/fallout/clothing_w/suit.dmi'
 
 /obj/item/clothing/suit/armor/f13/combatmk2
@@ -434,7 +431,6 @@
 	item_state = "combat_armor_mk2"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/combatmk2ncr
 	name = "combat armor mk2"
@@ -443,7 +439,6 @@
 	item_state = "combat_armor_mk2_ncr"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 	icon = 'icons/fallout/clothing_w/suit.dmi'
 
 /obj/item/clothing/suit/armor/f13/combatmk2leg
@@ -453,7 +448,6 @@
 	item_state = "combat_armor_mk2_leg"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 	icon = 'icons/fallout/clothing_w/suit.dmi'
 
 /obj/item/clothing/suit/armor/f13/combatbosrein
@@ -463,9 +457,7 @@
 	item_state = "combat_armor_reinforced_bos"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 	icon = 'icons/fallout/clothing_w/suit.dmi'
-
 
 /obj/item/clothing/suit/armor/f13/combatrein
 	name = "Reinforced Combat Armor"
@@ -474,7 +466,6 @@
 	item_state = "combat_armor_reinforced"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 	icon = 'icons/fallout/clothing_w/suit.dmi'
 
 /obj/item/clothing/suit/armor/f13/scoutarmor
@@ -484,7 +475,6 @@
 	item_state = "scout_armor_lt"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/atomzealot
 	name = "zealot armor"
@@ -493,7 +483,6 @@
 	item_state = "atomzealot"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 30, "bullet" = 35, "laser" = 40, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 100, "fire" = 60, "acid" = 20)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/atomwitch
 	name = "atomic seer robes"
@@ -511,7 +500,6 @@
 	item_state = "caeser_pelt"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 45, "bullet" = 55, "laser" = 45, "energy" = 45, "bomb" = 55, "bio" = 65, "rad" = 10, "fire" = 60, "acid" = 20)
-
 
 /obj/item/clothing/suit/armor/f13/combat/dark
 	name = "combat armor"
@@ -545,8 +533,6 @@
 	desc = "A set of standard issue ranger patrol armor that provides defense similar to a suit of pre-war combat armor."
 	icon_state = "ncr_patrol"
 	item_state = "ncr_patrol"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list("melee" = 40, "bullet" = 45, "laser" = 40, "energy" = 40, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 20)
 
 /obj/item/clothing/suit/armor/f13/combat/brotherhood
 	name = "brotherhood combat armor"
@@ -591,7 +577,6 @@
 	item_state = "ranger"
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	armor = list("melee" = 55, "bullet" = 55, "laser" = 55, "energy" = 40, "bomb" = 55, "bio" = 60, "rad" = 60, "fire" = 90, "acid" = 20)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/rangercombat/desert
 	name = "desert ranger combat armor"
@@ -642,7 +627,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 60, "bullet" = 40, "laser" = 40, "energy" = 30, "bomb" = 25, "bio" = 30, "rad" = 30, "fire" = 90, "acid" = 0)
 	slowdown = 0.75
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/kit/terrible
 	name = "scorched armor kit"
@@ -667,7 +651,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 65, "bullet" = 40, "laser" = 50, "energy" = 60, "bomb" = 25, "bio" = 30, "rad" = 30, "fire" = 90, "acid" = 0)
 	slowdown = 0.75
-	strip_delay = 60
 */
 // salvaged/broken power armor, does not require PA training
 
@@ -816,14 +799,12 @@
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	allowed = list(/obj/item/gun, /obj/item/claymore, /obj/item/throwing_star/spear, /obj/item/restraints/legcuffs/bola, /obj/item/twohanded)
 	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/legion/recruit
 	name = "legion recruit armor"
 	desc = "Legion recruit armor is a common light armor, supplied to recruit legionaries and to recruit decanus units. Like most Legion armor, it is made from repurposed sports equipment, consisting of a football player's protective shoulder and chest pads reinforced with additional leather padding and worn over a baseball catcher's vest."
 	icon_state = "legrecruit"
 	slowdown = -0.15
-	armor = list("melee" = 40, "bullet" = 25, "laser" = 10, "energy" = 10, "bomb" = 16, "bio" = 30, "rad" = 20, "fire" = 50, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legion/recruit/scout
 	name = "legion scout armor"
@@ -886,7 +867,6 @@
 	name = "paladin-slayer centurion armor"
 	desc = "The armor of a Centurion who has bested one or more Brotherhood Paladins, adding pieces of his prizes to his own defense. The symbol of the Legion is crudely painted on this once-marvelous suit of armor."
 	icon_state = "palacent"
-	slowdown = 0
 	armor = list("melee" = 75, "bullet" = 50, "laser" = 35, "energy" = 35, "bomb" = 39, "bio" = 60, "rad" = 20, "fire" = 80, "acid" = 0)
 
 /obj/item/clothing/suit/armor/f13/legion/rangercent
@@ -911,7 +891,6 @@
 	item_state = "ncr_infantry_vest"
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	armor = list("melee" = 40, "bullet" = 35, "laser" = 20, "energy" = 20, "bomb" = 25, "bio" = 30, "rad" = 20, "fire" = 60, "acid" = 0)
-	strip_delay = 60
 
 /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
 	name = "NCR mantle vest"

--- a/code/modules/clothing/suits/f13.dm
+++ b/code/modules/clothing/suits/f13.dm
@@ -147,8 +147,6 @@
 	item_state = "hazmat_helmet"
 	flags_inv = HIDEMASK|HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
 
-
-
 //Fallout 13 toggle apparel directory
 
 /obj/item/clothing/suit/toggle/labcoat/f13
@@ -193,4 +191,3 @@
 	body_parts_covered = CHEST
 	armor = list(melee = 0, bullet = 0, laser = 10, energy = 10, bomb = 0, bio = 10, rad = 10, fire = 10, acid = 10)
 	allowed = list(/obj/item/pen,/obj/item/paper,/obj/item/stamp,/obj/item/reagent_containers/food/drinks/flask,/obj/item/storage/box/matches,/obj/item/lighter,/obj/item/clothing/mask/cigarette,/obj/item/storage/fancy/cigarettes,/obj/item/flashlight,/obj/item/ammo_box,/obj/item/ammo_casing,/obj/item/scalpel,/obj/item/surgical_drapes,/obj/item/cautery,/obj/item/hemostat,/obj/item/retractor,/obj/item/storage/pill_bottle/dice,/obj/item/dice)
-

--- a/code/modules/clothing/suits/f13_armor.dm
+++ b/code/modules/clothing/suits/f13_armor.dm
@@ -2,7 +2,6 @@
 
 /obj/item/clothing/suit/armor/f13
 
-
 /obj/item/clothing/suit/armor/f13/cyberpunk
 	name = "armored trenchcoat"
 	desc = "A trenchcoat augmented with a special alloy for some protection and style."
@@ -42,7 +41,6 @@
 	desc = "A set of armor made of gecko hides.<br>It's pretty good for makeshift armor."
 	icon_state = "tribal"
 	item_state = "tribal"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list(melee = 30, bullet = 20, laser = 20, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 10, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 40
@@ -53,7 +51,6 @@
 	desc = "Crude armor that appears to employ a tire of some kind as the shoulder pad. What appears to be a quilt is tied around the waist.<br>Come on and slam and turn your foes to jam!"
 	icon_state = "slam"
 	item_state = "slam"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list(melee = 30, bullet = 30, laser = 30, energy = 0, bomb = 10, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 40
@@ -64,7 +61,6 @@
 	desc = "A set of light armor made of boiled brahmin leather.<br>It should protect against the average 9mm peashooter, but anything higher caliber will punch through it like butter."
 	icon_state = "leatherarmor"
 	item_state = "leatherarmor"
-	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	armor = list(melee = 40, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 0, fire = 0, acid = 0)
 	flags_inv = HIDEJUMPSUIT
 	strip_delay = 40
@@ -76,41 +72,41 @@
 	desc = "A set of hand-crafted metal armor created from a variety of scrap pieces attached to a black leather base layer."
 	icon_state = "raidermetal"
 	item_state = "raidermetal"
-	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
 	armor = list(melee = 40, bullet = 30, laser = 20, energy = 20, bomb = 30, bio = 0, rad = 0, fire = 10, acid = 0)
-	strip_delay = 60
 	resistance_flags = FIRE_PROOF
 	icon = 'icons/fallout/clothing/suits.dmi'
 /*
-///obj/item/clothing/suit/armor/f13/bmetalarmor //uses the same path as bmetalarmor in armor.dm, causing the assless chaps bug
-//	name = "black metal armor"
-//	desc = "A set of sturdy metal armor made from various bits of scrap metal. It looks like it might impair movement."
-//	icon_state = "bmetalarmor"
-//	item_state = "bmetalarmor"
-//	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS
-//	armor = list(melee = 50, bullet = 40, laser = 30, energy = 30, bomb = 40, bio = 0, rad = 0, fire = 20, acid = 0)
-//	flags_inv = HIDEJUMPSUIT
-//	strip_delay = 60
-//	resistance_flags = FIRE_PROOF
-//	icon = 'icons/fallout/clothing/suits.dmi'
+/obj/item/clothing/suit/armor/f13/bmetalarmor //uses the same path as bmetalarmor in armor.dm, causing the assless chaps bug
+	name = "black metal armor"
+	desc = "A set of sturdy metal armor made from various bits of scrap metal. It looks like it might impair movement."
+	icon_state = "bmetalarmor"
+	item_state = "bmetalarmor"
+	armor = list(melee = 50, bullet = 40, laser = 30, energy = 30, bomb = 40, bio = 0, rad = 0, fire = 20, acid = 0)
+	flags_inv = HIDEJUMPSUIT
+	resistance_flags = FIRE_PROOF
+	icon = 'icons/fallout/clothing/suits.dmi'
+*/
 /obj/item/clothing/suit/armor/f13/ncrarmor/soldier
 	name = "standard issue trooper armor"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons, and gauntlets, worn by NCR soldiers in combat environments.<br>This one has had its breastplate emblazoned with the emblem of the NCR, that has slightly faded over time."
 	icon_state = "ncr_armor2"
 	item_state = "ncr_armor2"
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/patriot
 	name = "trooper armor of \"Patriot\" battalion"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons and gauntlets, worn by NCR patriots in combat environments.<br>This one has a five-pointed star painted over the chestplate with white paint - it must be a battalion insignia."
 	icon_state = "ncr_armor3"
 	item_state = "ncr_armor3"
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/commie
 	name = "trooper armor of \"Commie\" battalion"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons and gauntlets, worn by NCR comrades in combat environments.<br>This one has a five-pointed star painted over the chestplate with red paint - it must be a battalion insignia."
 	icon_state = "ncr_armor4"
 	item_state = "ncr_armor4"
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/preacher
 	name = "trooper armor of \"Preacher\" battalion"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons and gauntlets, worn by NCR zealots in combat environments.<br>This one has a holy cross painted over the chestplate with yellow paint - it must be a battalion insignia."
@@ -123,18 +119,21 @@
 	icon_state = "ncr_armor6"
 	item_state = "ncr_armor6"
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/stalker //Cheeki breeki i v damke !!!
 	name = "trooper armor of \"Stalker\" battalion"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons and gauntlets, worn by NCR explorers in combat environments.<br>This one has a radiation symbol painted over the chestplate with yellow paint - it must be a battalion insignia."
 	icon_state = "ncr_armor7"
 	item_state = "ncr_armor7"
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/punisher
 	name = "trooper armor of \"Punisher\" battalion"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons and gauntlets, worn by NCR heroes and villains in combat environments.<br>This one has a skull symbol painted over the chestplate with white paint - it must be a battalion insignia."
 	icon_state = "ncr_armor8"
 	item_state = "ncr_armor8"
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/ncrarmor/facewrap
 	name = "face wrap armor"
 	desc = "A set of NCR armor that consists of an armored breastplate, metal pauldrons and gauntlets, worn by NCR scouts in combat environments.<br>This one has the facewrap, designed to be pulled over the user's face to protect oneself from dust particles and other mainly radioactive elements."
@@ -142,6 +141,7 @@
 	item_state = "ncr_armor9"
 	armor = list(melee = 30, bullet = 20, laser = 10, energy = 10, bomb = 20, bio = 0, rad = 30, fire = 10, acid = 10) //Better radiation protection, thank the facewrap bro!
 	icon = 'icons/fallout/clothing/suits.dmi'
+
 /obj/item/clothing/suit/armor/f13/rangercombat/old
 	name = "worn veteran ranger combat armor"
 	desc = "A unique armor, that has been in countless battles and caused much bloodshed."
@@ -168,7 +168,6 @@
 	item_state = "vault_commandcoat"
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 
-
 //Knights of the Apocalypse
 
 /obj/item/clothing/suit/armor/riot/knight
@@ -176,6 +175,7 @@
 	desc = "A classic suit of plate armour, highly effective at stopping melee attacks."
 	icon_state = "knight_green"
 	item_state = "knight_green"
+
 /obj/item/clothing/suit/armor/riot/knight/yellow
 	icon_state = "knight_yellow"
 	item_state = "knight_yellow"

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -44,7 +44,6 @@
 	icon_state = "hgpirate"
 	item_state = "hgpirate"
 
-
 /obj/item/clothing/suit/cyborg_suit
 	name = "cyborg suit"
 	desc = "Suit for a cyborg costume."
@@ -54,14 +53,12 @@
 	fire_resist = T0C+5200
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
-
 /obj/item/clothing/suit/justice
 	name = "justice suit"
 	desc = "this pretty much looks ridiculous" //Needs no fixing
 	icon_state = "justice"
 	item_state = "justice"
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
-
 
 /obj/item/clothing/suit/judgerobe
 	name = "judge's robe"
@@ -71,7 +68,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/storage/fancy/cigarettes, /obj/item/stack/spacecash)
 	flags_inv = HIDEJUMPSUIT
-
 
 /obj/item/clothing/suit/apron/overalls
 	name = "coveralls"
@@ -105,7 +101,6 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	flags_inv = HIDEGLOVES|HIDESHOES|HIDEJUMPSUIT
 
-
 /obj/item/clothing/suit/imperium_monk
 	name = "\improper Imperium monk suit"
 	desc = "Have YOU killed a xeno today?"
@@ -115,7 +110,6 @@
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen)
 
-
 /obj/item/clothing/suit/chickensuit
 	name = "chicken suit"
 	desc = "A suit made long ago by the ancient empire KFC."
@@ -123,7 +117,6 @@
 	item_state = "chickensuit"
 	body_parts_covered = CHEST|ARMS|GROIN|LEGS|FEET
 	flags_inv = HIDESHOES|HIDEJUMPSUIT
-
 
 /obj/item/clothing/suit/monkeysuit
 	name = "monkey suit"
@@ -151,7 +144,6 @@
 	desc = "A plush white cloak made of synthetic feathers. Soft to the touch, stylish, and a 2 meter wing span that will drive your captives mad."
 	icon_state = "griffin_wings"
 	item_state = "griffin_wings"
-
 
 /obj/item/clothing/suit/holidaypriest
 	name = "holiday priest"
@@ -190,7 +182,6 @@
 			I.add_overlay(mutable_appearance('icons/mob/robots.dmi', "robot_e")) //gotta look realistic
 			add_alt_appearance(/datum/atom_hud/alternate_appearance/basic/silicons, "standard_borg_disguise", I) //you look like a robot to robots! (including yourself because you're totally a robot)
 
-
 /obj/item/clothing/suit/snowman
 	name = "snowman outfit"
 	desc = "Two white spheres covered in white glitter. 'Tis the season."
@@ -207,7 +198,6 @@
 	body_parts_covered = CHEST
 	armor = list(melee = 10, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	allowed = list(/obj/item/pen,/obj/item/paper,/obj/item/stamp,/obj/item/reagent_containers/food/drinks/flask,/obj/item/storage/box/matches,/obj/item/lighter,/obj/item/clothing/mask/cigarette,/obj/item/storage/fancy/cigarettes,/obj/item/flashlight,/obj/item/gun,/obj/item/ammo_box,/obj/item/ammo_casing)
-
 
 /obj/item/clothing/suit/poncho/green
 	name = "green poncho"
@@ -304,7 +294,6 @@
 	allowed = list()
 	actions_types = list(/datum/action/item_action/toggle_human_head)
 	hoodtype = /obj/item/clothing/head/hooded/human_head
-
 
 /obj/item/clothing/head/hooded/human_head
 	name = "bloated human head"
@@ -460,8 +449,6 @@
 	icon_state = "pharoah"
 	icon_state = "pharoah"
 	body_parts_covered = CHEST|GROIN
-
-
 
 // WINTER COATS
 
@@ -619,7 +606,6 @@
 /obj/item/clothing/head/hooded/winterhood/blue113
 	icon_state = "winterhood_blue113"
 
-
 //Fallout 13
 /obj/item/clothing/suit/fluff
 	allowed = list(/obj/item/gun)
@@ -631,7 +617,6 @@
 	item_state = "det_suit"
 	body_parts_covered = CHEST
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/fluff/battlecruiser //Do we have Star Craft here as well?!
 	name = "captain's coat"
@@ -640,7 +625,6 @@
 	item_state = "hostrench"
 	body_parts_covered = CHEST|ARMS
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/fluff/cowboybvest //Originally cowboy stuff by Nienhaus
 	name = "brown vest"
@@ -649,7 +633,6 @@
 	item_state = "lb_suit"
 	body_parts_covered = CHEST|GROIN
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/fluff/cowboygvest
 	name = "grey vest"
@@ -658,7 +641,6 @@
 	item_state = "gy_suit"
 	body_parts_covered = CHEST|GROIN
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/f13/mfp //Mad Max 1979 babe!
 	name = "mfp jacket"
@@ -668,7 +650,6 @@
 	body_parts_covered = CHEST|ARMS|LEGS
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 0, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	flags_inv = HIDEJUMPSUIT
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/f13/veteran
 	name = "merc veteran coat"
@@ -677,7 +658,6 @@
 	item_state = "suit-command"
 	body_parts_covered = CHEST|GROIN
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/f13/duster
 	name = "duster"
@@ -686,7 +666,6 @@
 	item_state = "det_suit"
 	body_parts_covered = CHEST|LEGS|FEET|ARMS
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/f13/autumn //Based of Colonel Autumn's uniform.
 	name = "tan trenchcoat"
@@ -695,8 +674,6 @@
 	item_state = "autumn"
 	body_parts_covered = CHEST|LEGS|ARMS
 	armor = list("melee" = 10, "bullet" = 16, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
-
 
 /obj/item/clothing/suit/f13/scribe
 	name = "Brotherhood Scribe's robe"
@@ -705,7 +682,6 @@
 	item_state = "scribe"
 	body_parts_covered = CHEST|ARMS|LEGS
 	armor = list("melee" = 15, "bullet" = 16, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/f13/seniorscribe
 	name = "Brotherhood Senior Scribe's robe"
@@ -714,7 +690,6 @@
 	item_state = "seniorscribe"
 	body_parts_covered = CHEST|ARMS|LEGS
 	armor = list("melee" = 15, "bullet" = 16, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/f13/elder //Robes are made of finest cloth, so you won't be able to put sharp objects but pens in.
 	name = "Brotherhood Elder's robe"
@@ -723,7 +698,6 @@
 	item_state = "elder"
 	body_parts_covered = CHEST|ARMS|LEGS
 	armor = list("melee" = 15, "bullet" = 16, "laser" = 15, "energy" = 0, "bomb" = 16, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
-	allowed = list(/obj/item/gun)
 
 /obj/item/clothing/suit/ghost_sheet
 	name = "ghost sheet"
@@ -735,4 +709,3 @@
 	throw_range = 2
 	w_class = WEIGHT_CLASS_TINY
 	flags_inv = HIDEGLOVES|HIDEEARS|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR
-

--- a/code/modules/clothing/under/f13.dm
+++ b/code/modules/clothing/under/f13.dm
@@ -1,10 +1,13 @@
 /obj/item/clothing/under/f13
+	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0) //Base type has no armor as well
 	body_parts_covered = CHEST|GROIN|ARMS|LEGS
 	fitted = NO_FEMALE_UNIFORM
 	can_adjust = FALSE
 	resistance_flags = NONE
 	has_sensor = NO_SENSORS //kek
 
+/obj/item/clothing/under/f13/female
+	fitted = FEMALE_UNIFORM_TOP
 
 //Vault
 
@@ -32,14 +35,13 @@
 	random_sensor = FALSE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 20, "acid" = 50)
 
-
 //NCR
 
 /obj/item/clothing/under/f13/ncr
 	name = "NCR desert fatigues"
 	desc = "A set of standard issue New California Republic trooper fatigues."
 	icon_state = "ncr_uniform"
-	can_adjust = 1
+	can_adjust = TRUE
 	item_state = "ncr_uniform"
 	item_color = "ncr_uniform"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 20, "acid" = 50)
@@ -166,7 +168,6 @@
 	item_color = "chef"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 20, "acid" = 50)
 
-
 //Brotherhood of Steel
 
 /obj/item/clothing/under/f13/recon
@@ -176,7 +177,6 @@
 	item_state = "recon"
 	item_color = "recon"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 40, "fire" = 30, "acid" = 80)
-
 
 //Legion
 
@@ -265,6 +265,7 @@
 	desc = "A Pink Vest with Black Pants. Quite futuristic looking."
 	icon_state = "Biker"
 	item_state = "Biker"
+
 /* //slave rags, crafted from 2 cloth- uncomment when sprites available
 /obj/item/clothing/under/f13/slaverags
 	name = "slave rags"
@@ -272,6 +273,7 @@
 	icon_state = "slaverags"
 	item_state = "slaverags"
 */
+
 /obj/item/clothing/under/f13/erpdress
 	name = "bandage dress"
 	desc = "Made by the famous pre-war fashion designer Marie Calluna, this dress was made to hug your every curve and show off some deep cleavage."
@@ -335,7 +337,6 @@
 	item_state = "follower"
 	item_color = "follower"
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-
 
 //Gangs
 /obj/item/clothing/under/f13/raider_leather
@@ -439,13 +440,9 @@
 	icon_state = "enclave_o"
 	item_state = "bl_suit"
 	item_color = "enclave_o"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 //Fallout 13 general clothing directory
-
-/obj/item/clothing/under/f13
 
 /obj/item/clothing/under/f13/navy
 	name = "navy jumpsuit"
@@ -453,9 +450,6 @@
 	icon_state = "navy"
 	item_state = "bl_suit"
 	item_color = "navy"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/navyofficer
 	name = "navy officer jumpsuit"
@@ -463,9 +457,6 @@
 	icon_state = "navyofficer"
 	item_state = "bl_suit"
 	item_color = "navyofficer"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/machinist
 	name = "workman outfit"
@@ -473,7 +464,6 @@
 	icon_state = "machinist"
 	item_state = "lb_suit"
 	item_color = "machinist"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/lumberjack
@@ -482,7 +472,6 @@
 	icon_state = "lumberjack"
 	item_state = "r_suit"
 	item_color = "lumberjack"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/police
 	name = "pre-War police uniform"
@@ -492,7 +481,6 @@
 	item_color = "retro_police"
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 10, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/cowboyt //Originally cowboy and mafia stuff by Nienhaus
 	name = "dusty prospector outfit"
@@ -500,7 +488,6 @@
 	icon_state = "cowboyt"
 	item_state = "det"
 	item_color = "cowboyt"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/cowboyb
@@ -508,8 +495,6 @@
 	desc = "A white shirt with brass buttons and a pair of brown trousers, commonly worn by prospectors."
 	icon_state = "cowboyb"
 	item_state = "det"
-	item_color = "cowboyb"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/cowboyg
@@ -518,7 +503,6 @@
 	icon_state = "cowboyg"
 	item_state = "sl_suit"
 	item_color = "cowboyg"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/female/flapper
@@ -527,8 +511,6 @@
 	icon_state = "flapper"
 	item_state = "gy_suit"
 	item_color = "flapper"
-	fitted = FEMALE_UNIFORM_TOP
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bdu //WalterJe military standarts.
 	name = "battle dress uniform"
@@ -536,9 +518,7 @@
 	icon_state = "bdu"
 	item_state = "xenos_suit"
 	item_color = "bdu"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 1
+	can_adjust = TRUE
 
 /obj/item/clothing/under/f13/dbdu
 	name = "desert battle dress uniform"
@@ -546,9 +526,8 @@
 	icon_state = "dbdu"
 	item_state = "brownjsuit"
 	item_color = "dbdu"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 1
+	can_adjust = TRUE
 
 /obj/item/clothing/under/f13/shiny //Firefly, yay!
 	name = "shiny outfit"
@@ -556,7 +535,6 @@
 	icon_state = "shiny"
 	item_state = "owl"
 	item_color = "shiny"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/batter //I guess we're going OFF limits.
 	name = "worn baseball uniform"
@@ -564,7 +542,6 @@
 	icon_state = "batter"
 	item_state = "w_suit"
 	item_color = "batter"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bennys //Benny's suit from Fallout: New Vegas. But Benny was just a kid back in 2255, so it's just a fancy suit for you.
 	name = "fancy suit"
@@ -572,7 +549,6 @@
 	icon_state = "benny"
 	item_state = "white_suit"
 	item_color = "benny"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/relaxedwear
 	name = "pre-war male relaxedwear"
@@ -580,7 +556,6 @@
 	icon_state = "relaxedwear_m"
 	item_state = "g_suit"
 	item_color = "relaxedwear_m"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/spring
 	name = "pre-war male spring outfit"
@@ -588,7 +563,6 @@
 	icon_state = "spring_m"
 	item_state = "brownjsuit"
 	item_color = "spring_m"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/formal
 	name = "pre-war male formal wear"
@@ -596,9 +570,6 @@
 	icon_state = "formal_m"
 	item_state = "judge"
 	item_color = "formal_m"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bodyguard
 	name = "bodyguard outfit"
@@ -606,9 +577,6 @@
 	icon_state = "bodyguard"
 	item_state = "sl_suit"
 	item_color = "bodyguard"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/rag
 	name = "torn rags"
@@ -632,7 +600,8 @@
 	icon_state = "tribal_f"
 	item_state = "lgloves"
 	item_color = "tribal_f"
-	can_adjust = 0
+	can_adjust = TRUE
+	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/f13/settler
 	name = "settler outfit"
@@ -640,7 +609,6 @@
 	icon_state = "settler"
 	item_state = "brownjsuit"
 	item_color = "settler"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/brahmin //Male version
@@ -649,7 +617,6 @@
 	icon_state = "brahmin_m"
 	item_state = "brownjsuit"
 	item_color = "brahmin_m"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/female/brahmin //Female version
 	name = "female brahmin-skin outfit"
@@ -657,8 +624,6 @@
 	icon_state = "brahmin_f"
 	item_state = "brownjsuit"
 	item_color = "brahmin_f"
-	fitted = FEMALE_UNIFORM_TOP
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/doctor //Male version
 	name = "male doctor fatigues"
@@ -666,7 +631,6 @@
 	icon_state = "doctor_m"
 	item_state = "brownjsuit"
 	item_color = "doctor_m"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/female/doctor //Female version
@@ -675,9 +639,7 @@
 	icon_state = "doctor_f"
 	item_state = "brownjsuit"
 	item_color = "doctor_f"
-	fitted = FEMALE_UNIFORM_TOP
-	can_adjust = 0
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
+	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/f13/mercadv //Male version
 	name = "male merc adventurer outfit"
@@ -685,9 +647,7 @@
 	icon_state = "merca_m"
 	item_state = "bl_suit"
 	item_color = "merca_m"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/female/mercadv //Female version
 	name = "female merc adventurer outfit"
@@ -695,11 +655,7 @@
 	icon_state = "merca_f"
 	item_state = "bl_suit"
 	item_color = "merca_f"
-	fitted = FEMALE_UNIFORM_TOP
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
-
+	fitted = NO_FEMALE_UNIFORM
 
 /obj/item/clothing/under/f13/merccharm //Male version
 	name = "male merc charmer outfit"
@@ -707,9 +663,7 @@
 	icon_state = "mercc_m"
 	item_state = "bl_suit"
 	item_color = "mercc_m"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/female/merccharm //Female version
 	name = "female merc charmer outfit"
@@ -717,10 +671,7 @@
 	icon_state = "mercc_f"
 	item_state = "bl_suit"
 	item_color = "mercc_f"
-	fitted = FEMALE_UNIFORM_TOP
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/mechanic
 	name = "worn blue jumpsuit"
@@ -728,7 +679,6 @@
 	icon_state = "mechanic"
 	item_state = "syndicate-blue"
 	item_color = "mechanic"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/petrochico
@@ -737,7 +687,6 @@
 	icon_state = "petrochico"
 	item_state = "centcom"
 	item_color = "petrochico"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/caravaneer
@@ -746,7 +695,6 @@
 	icon_state = "caravaneer"
 	item_state = "syndicate-blue"
 	item_color = "caravaneer"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 10, "fire" = 10, "acid" = 40)
 
 /obj/item/clothing/under/f13/trader
@@ -755,7 +703,6 @@
 	icon_state = "trader"
 	item_state = "bl_suit"
 	item_color = "trader"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/merchant
@@ -764,7 +711,6 @@
 	icon_state = "merchant"
 	item_state = "brownjsuit"
 	item_color = "merchant"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/worn
@@ -773,7 +719,6 @@
 	icon_state = "worn"
 	item_state = "brownjsuit"
 	item_color = "worn"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/vault
 	name = "vault jumpsuit"
@@ -781,7 +726,7 @@
 	icon_state = "vault"
 	item_state = "b_suit"
 	item_color = "vault"
-	can_adjust = 1
+	can_adjust = TRUE
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 10, "rad" = 30, "fire" = 30, "acid" = 40)
 
 /obj/item/clothing/under/f13/vault/v13 //The Legend is here.
@@ -814,7 +759,6 @@
 	icon_state = "followers"
 	item_state = "bar_suit"
 	item_color = "followers"
-	can_adjust = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
 
 /obj/item/clothing/under/f13/combat
@@ -823,9 +767,7 @@
 	icon_state = "combat"
 	item_state = "bl_suit"
 	item_color = "combat"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/enclave_officer
 	name = "officer uniform"
@@ -833,9 +775,7 @@
 	icon_state = "enclave_o"
 	item_state = "bl_suit"
 	item_color = "enclave_o"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/ncr/torn
 	name = "torn overcoat"
@@ -844,7 +784,6 @@
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 	icon_state = "tornovercoat"
 	item_color = "tornovercoat"
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/general
 	name = "general overcoat"
@@ -852,9 +791,7 @@
 	icon_state = "general"
 	item_state = "lb_suit"
 	item_color = "general"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 40, "acid" = 40)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/recon
 	name = "recon armor"
@@ -862,12 +799,10 @@
 	icon_state = "recon"
 	item_state = "rig_suit"
 	item_color = "recon"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS|HEAD
 	flags_inv = HIDEHAIR
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 30, "fire" = 30, "acid" = 40)
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HEAD
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HEAD
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/chinese
 	name = "chinese jumpsuit"
@@ -875,12 +810,9 @@
 	icon_state = "chinese"
 	item_state = "bl_suit"
 	item_color = "chinese"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 20, "fire" = 20, "acid" = 40)
-	can_adjust = 0
 
 //Fluff
-
 
 /obj/item/clothing/under/f13/agent47
 	name = "mysterious suit"
@@ -888,9 +820,6 @@
 	icon_state = "agent47"
 	item_state = "lawyer_black"
 	item_color = "agent47"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/psychologist
 	name = "psychologist's turtleneck"
@@ -898,19 +827,12 @@
 	icon_state = "psychturtle"
 	item_state = "b_suit"
 	item_color = "psychturtle"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
-
 /obj/item/clothing/under/f13/villain //Doubles as Gang Leader primary uniform for extra villainy
 	name = "green and black suit"
 	desc = "There is something evil in this suit, only a villain would wear something like that."
 	icon_state = "villain"
 	item_state = "syndicate-green"
 	item_color = "villain"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0) //Because dying is fun. Especially for evil masterminds.
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/gentlesuit
 	name = "gentlemans suit"
@@ -918,9 +840,6 @@
 	icon_state = "gentlesuit"
 	item_state = "gy_suit"
 	item_color = "gentlesuit"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/detectivealt
 	name = "fancy detective suit"
@@ -928,9 +847,7 @@
 	icon_state = "detectivealt"
 	item_state = "bl_suit"
 	item_color = "detectivealt"
-	body_parts_covered = CHEST|GROIN|LEGS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 1
+	can_adjust = TRUE
 
 /obj/item/clothing/under/f13/hopalt
 	name = "head of personnel's suit"
@@ -938,9 +855,6 @@
 	icon_state = "hopalt"
 	item_state = "b_suit"
 	item_color = "hopalt"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 20, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/roboticistalt
 	name = "roboticist's jumpsuit"
@@ -948,9 +862,7 @@
 	icon_state = "roboticsalt"
 	item_state = "jensensuit"
 	item_color = "roboticsalt"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 10, energy = 10, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 1
+	can_adjust = TRUE
 
 /obj/item/clothing/under/f13/bartenderalt
 	name = "fancy bartender's uniform"
@@ -958,9 +870,6 @@
 	icon_state = "barmanalt"
 	item_state = "bl_suit"
 	item_color = "barmanalt"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/spaceship
 	name = "crewman uniform"
@@ -968,25 +877,18 @@
 	icon_state = "spaceship_crewman"
 	item_state = "syndicate-black-red"
 	item_color = "spaceship_crewman"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/spaceship/officer
 	name = "officer uniform"
 	desc = "The insignia on this uniform tells you that this uniform belongs to some sort of officer."
 	icon_state = "spaceship_officer"
 	item_color = "spaceship_officer"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 
 /obj/item/clothing/under/f13/spaceship/captain
 	name = "captain uniform"
 	desc = "The insignia on this uniform tells you that this uniform belongs to some sort of captain."
 	icon_state = "spaceship_captain"
 	item_color = "spaceship_captain"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 
 //Female clothing! It's not misogyny, yet dresses shall be separate from /f13/ as Fallout build has its own female subtype.
 
@@ -1014,7 +916,6 @@
 	icon_state = "khan"
 	item_color = "khan"
 	body_parts_covered = LEGS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 
 /obj/item/clothing/under/pants/f13/warboy //Mad Max 4 2015 babe!
 	name = "war boy pants"
@@ -1022,7 +923,6 @@
 	icon_state = "warboy"
 	item_color = "warboy"
 	body_parts_covered = LEGS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
 
 /obj/item/clothing/under/pants/f13/doom
 	name = "green pants"
@@ -1031,8 +931,6 @@
 	item_color = "green"
 	resistance_flags = UNACIDABLE
 	body_parts_covered = LEGS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-
 
 /obj/item/clothing/under/f13/bosform_f
 	name = "female initiate service uniform"
@@ -1040,9 +938,6 @@
 	icon_state = "bosform_f"
 	item_state = "bosform_f"
 	item_color = "bosform_f"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bosform_m
 	name = "male initiate service uniform"
@@ -1050,9 +945,6 @@
 	icon_state = "bosform_m"
 	item_state = "bosform_m"
 	item_color = "bosform_m"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bosformsilver_f
 	name = "female brotherhood service uniform"
@@ -1060,9 +952,6 @@
 	icon_state = "bosformsilver_f"
 	item_state = "bosformsilver_f"
 	item_color = "bosformsilver_f"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bosformsilver_m
 	name = "male brotherhood service uniform"
@@ -1070,9 +959,6 @@
 	icon_state = "bosformsilver_m"
 	item_state = "bosformsilver_m"
 	item_color = "bosformsilver_m"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bosformgold_f
 	name = "female ranking service uniform"
@@ -1080,9 +966,6 @@
 	icon_state = "bosformgold_f"
 	item_state = "bosformgold_f"
 	item_color = "bosformgold_f"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/bosformgold_m
 	name = "male ranking service uniform"
@@ -1090,9 +973,6 @@
 	icon_state = "bosformgold_m"
 	item_state = "bosformgold_m"
 	item_color = "bosformgold_m"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/atomfaithful
 	name = "faithful attire"
@@ -1100,9 +980,6 @@
 	icon_state = "atomfaithful"
 	item_state = "atomfaithful"
 	item_color = "atomfaithful"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/atomwitchunder
 	name = "seers underclothes"
@@ -1110,9 +987,6 @@
 	icon_state = "atomwitchunder"
 	item_state = "atomwitchunder"
 	item_color = "atomwitchunder"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/atombeliever
 	name = "believer clothes"
@@ -1120,9 +994,6 @@
 	icon_state = "atombeliever"
 	item_state = "atombeliever"
 	item_color = "atombeliever"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/raiderharness
 	name = "raider harness"
@@ -1130,10 +1001,6 @@
 	icon_state = "raiderharness"
 	item_state = "raiderharness"
 	item_color = "raiderharness"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
-
 
 /obj/item/clothing/under/f13/fprostitute
 	name = "feminine prostitute outfit"
@@ -1141,9 +1008,6 @@
 	icon_state = "fprostitute"
 	item_state = "fprostitute"
 	item_color = "fprostitute"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
 
 /obj/item/clothing/under/f13/mprostitute
 	name = "masuline prostitute outfit"
@@ -1151,7 +1015,3 @@
 	icon_state = "mprostitute"
 	item_state = "mprostitute"
 	item_color = "mprostitute"
-	body_parts_covered = CHEST|GROIN|LEGS|ARMS
-	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 0, acid = 0)
-	can_adjust = 0
-


### PR DESCRIPTION

## Description
Code wise - This pr is to make the most clothing in the Fallout files to be standered in TRUE FALSE rather the 1-0 
Code wise to cut down on unneeded double stated vars

### Game wise this should not have any noticeable affect

## Motivation and Context
Lots of double defines that get harder and harder to read and look back on when coding as they should rather just be restate if changed
Unneeded file bloat makes everyones life harder
Standerised coding should be used to stop confusion for later date coders/lookers on what system to use

## How Has This Been Tested?
Nope
## Screenshots (if appropriate):
N/A
## Changelog (necessary)
:cl:
code: Cleans out double stated vars, swaps 1-0s to TRUE FALSE when needed and condensed down files, regarding clothing - And only clothing files

/:cl:
