### PR TITLE
Strange seeds can no longer make angel toxins

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -565,6 +565,7 @@
 	id = "flightpotion"
 	description = "Strange FEV solutionic compound of unknown origins."
 	reagent_state = LIQUID
+	can_synth = FALSE
 	color = "#FFEBEB"
 
 /datum/reagent/flightpotion/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)


### PR DESCRIPTION
## Description
I dont remember their being any angels in the the FA lore... Thus I am removing Strange seeds will to make it so

## Motivation and Context
Oversight on when the slime cores were fixed iirc to make sure the chem itself could not be made by /other/ means  - Strange seeds
"Why not just remove the chem?"
I can see this being used in RP for a vault testing or something if admins wanted to buss it or something, It could be fun for events as well
## How Has This Been Tested?
Yikes it hasnt!
## Screenshots (if appropriate):
Its quite hard to show something that dosnt spawn...
## Changelog (necessary)
:cl:
fix: Flight Potions -Angel Race Changing Chem- can no longer be made by strange seeds... Sorry Vaulties get your wings somewhere different!
/:cl:
