### PR TITLE
[Ready]Renames all cargo's "shuttle" and CC to CASP Printer area

### DIFF
--- a/code/game/area/areas/centcom.dm
+++ b/code/game/area/areas/centcom.dm
@@ -2,7 +2,7 @@
 // CENTCOM
 
 /area/centcom
-	name = "CentCom"
+	name = "CASP Printer Area"
 	icon_state = "centcom"
 	dynamic_lighting = DYNAMIC_LIGHTING_FORCED
 	requires_power = FALSE
@@ -12,16 +12,16 @@
 	flags_1 = NONE
 
 /area/centcom/control
-	name = "CentCom Docks"
+	name = "CASP Printer Docks"
 
 /area/centcom/evac
-	name = "CentCom Recovery Ship"
+	name = "CASP Printer Recovery Ship"
 
 /area/centcom/supply
-	name = "CentCom Supply Shuttle Dock"
+	name = "CASP Printer Supply Dock"
 
 /area/centcom/ferry
-	name = "CentCom Transport Shuttle Dock"
+	name = "CASP Printer Transport Dock"
 
 /area/centcom/prison
 	name = "Admin Prison"

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -1,20 +1,20 @@
 /obj/machinery/computer/cargo
 	name = "supply console"
-	desc = "Used to order supplies, approve requests, and control the shuttle."
+	desc = "Used to order supplies, approve requests, and control the CASP platform."
 	icon_screen = "supply"
 	circuit = /obj/item/circuitboard/computer/cargo
 	var/requestonly = FALSE
 	var/contraband = FALSE
-	var/safety_warning = "For safety reasons the CASP Printer area \
+	var/safety_warning = "For safety reasons the CASP platform \
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
-	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
+	var/blockade_warning = "Instability detected. CASP platform movement impossible."
 
 	light_color = "#E2853D"//orange
 
 /obj/machinery/computer/cargo/request
 	name = "supply request console"
-	desc = "Used to request supplies from cargo."
+	desc = "Used to request supplies from CASP platform."
 	icon_screen = "request"
 	circuit = /obj/item/circuitboard/computer/cargo/request
 	requestonly = TRUE
@@ -122,10 +122,10 @@
 				SSshuttle.supply.contraband = contraband
 				SSshuttle.moveShuttle("supply", "supply_away", TRUE)
 				say("The supply shuttle has departed.")
-				investigate_log("[key_name(usr)] sent the supply shuttle away.", INVESTIGATE_CARGO)
+				investigate_log("[key_name(usr)] sent the CASP platform away.", INVESTIGATE_CARGO)
 			else
-				investigate_log("[key_name(usr)] called the supply shuttle.", INVESTIGATE_CARGO)
-				say("The supply shuttle has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minutes.")
+				investigate_log("[key_name(usr)] called the CASP platform.", INVESTIGATE_CARGO)
+				say("The CASP platform has been called and will arrive in [SSshuttle.supply.timeLeft(600)] minutes.")
 				SSshuttle.moveShuttle("supply", "supply_home", TRUE)
 			. = TRUE
 		if("loan")
@@ -140,7 +140,7 @@
 				return
 			else
 				SSshuttle.shuttle_loan.loan_shuttle()
-				say("The supply shuttle has been loaned to CASP Printer area.")
+				say("The CASP platform has been loaned to CASP Printer area.")
 				. = TRUE
 		if("add")
 			var/id = text2path(params["id"])

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -5,7 +5,7 @@
 	circuit = /obj/item/circuitboard/computer/cargo
 	var/requestonly = FALSE
 	var/contraband = FALSE
-	var/safety_warning = "For safety reasons the automated supply shuttle \
+	var/safety_warning = "For safety reasons the CASP Printer area \
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
@@ -140,7 +140,7 @@
 				return
 			else
 				SSshuttle.shuttle_loan.loan_shuttle()
-				say("The supply shuttle has been loaned to CentCom.")
+				say("The supply shuttle has been loaned to CASP Printer area.")
 				. = TRUE
 		if("add")
 			var/id = text2path(params["id"])


### PR DESCRIPTION

## Description
When possable/needed Centcom and shuttle has been replaced with CASP Printer area
as pre Reeces request

## Motivation and Context
Reece asked

## How Has This Been Tested?
Nope

## Screenshots (if appropriate):
Cant get them
## Changelog (necessary)
:cl:
spellcheck: The CASP Printer area now docs with CASP Printer area rather then some "Centcom"
/:cl:
