### PR TITLE
Makes camp fire kit make campfires via alt click rather then crafting

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -60,14 +60,7 @@
 	name = "campfire kit"
 	result = /obj/item/crafting/campfirekit
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 15)
-	time = 80
-	category = CAT_MISC
-
-/datum/crafting_recipe/campfirekit
-	name = "set up campfire kit"
-	result = /obj/structure/campfire
-	reqs = list(/obj/item/crafting/campfirekit = 1)
-	time = 40
+	time = 120 // Around 12 seconds
 	category = CAT_MISC
 
 /datum/crafting_recipe/barrelfire

--- a/code/modules/fallout/obj/crafting.dm
+++ b/code/modules/fallout/obj/crafting.dm
@@ -168,5 +168,11 @@
 
 /obj/item/crafting/campfirekit
 	name = "campfire kit"
-	desc = "A small box filled with an assortment of wood and tender. Useful for quickly making a fire."
+	desc = "A small box filled with an assortment of wood and tender. Useful for quickly making a fire. Alt click to crate a camping fire."
 	icon_state = "lunchbox"
+
+/obj/item/crafting/campfirekit/AltClick(mob/user)
+	. = ..()
+	var/turf/T = get_turf(usr)
+	new /obj/structure/campfire(T)
+	return ..()

--- a/code/modules/fallout/obj/crafting.dm
+++ b/code/modules/fallout/obj/crafting.dm
@@ -175,4 +175,3 @@
 	. = ..()
 	var/turf/T = get_turf(usr)
 	new /obj/structure/campfire(T)
-	return ..()


### PR DESCRIPTION
## Description
Alt click a fire kit to make a camp fire!

## Motivation and Context
Less crafting menu bloat

## How Has This Been Tested?
Its not, likely dosnt work

## Screenshots (if appropriate):
Its not needed
## Changelog (necessary)
:cl:
tweak: Camp fire kits now deploy into a camp fire rather then crafting into one. How novel 
tweak: Also, raises the crafting time of the camp fire kit to 120 from 80 (4 more seconds)
/:cl:
