### PR TITLE
Adds OOC clickable link blocking

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -19,6 +19,8 @@
 	config_entry_value = 25
 	min_val = 0
 
+/datum/config_entry/flag/blockoocurls	// log OOC channel
+
 /datum/config_entry/flag/hub	// if the game appears on the hub or not
 
 /datum/config_entry/flag/log_ooc	// log OOC channel

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -51,7 +51,12 @@
 			log_admin("[key_name(src)] has triggered the slur filter (OOC): [msg].")
 			message_admins("[key_name_admin(src)] has triggered the slur filter (OOC): [msg].")
 			return
-
+		if(CONFIG_GET(flag/blockoocurls))
+			if(findtext(msg, "://") || findtext(msg, "www."))
+				to_chat(src, "<B>Posting clickable links in OOC is not allowed.</B>")
+				log_admin("[key_name(src)] has attempted to post a clickable link in OOC: [msg]")
+				message_admins("[key_name_admin(src)] has attempted to post a clickable link in OOC: [msg]")
+				return
 	if(!(prefs.chat_toggles & CHAT_OOC))
 		to_chat(src, "<span class='danger'>You have OOC muted.</span>")
 		return

--- a/config/config.txt
+++ b/config/config.txt
@@ -473,3 +473,6 @@ BOT_IP 127.0.0.1:8081
 ##	For reference, Goonstation uses a resolution of 21x15 for it's widescreen mode.
 ##	Do note that changing this value will affect the title screen. The title screen will have to be updated manually if this is changed.
 DEFAULT_VIEW 15x15
+
+## Comment this out to enable clickable URLs from being posted in OOC
+BLOCKOOCURLS


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
Prevents clickable links from being posted/spammed in OOC. This is toggleable by config.

## Motivation and Context
To help with OOC spam, flexible enough to be disabled. Does not affect admins.

## How Has This Been Tested?
Direct port from Beestation.
https://github.com/BeeStation/BeeStation-Hornet/pull/1853/files

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: added url OOC block feature
config: adds toggleable ability to add ooc url blocking.
/:cl:
