### PR TITLE
Runechat Emergency Hotfix

### DIFF
--- a/code/datums/brain_damage/imaginary_friend.dm
+++ b/code/datums/brain_damage/imaginary_friend.dm
@@ -138,8 +138,6 @@
 	friend_talk(message)
 
 /mob/camera/imaginary_friend/Hear(message, atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode)
-	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
-		create_chat_message(speaker, message_language, raw_message, spans, message_mode)
 	to_chat(src, compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode))
 
 /mob/camera/imaginary_friend/proc/friend_talk(message)

--- a/code/modules/antagonists/disease/disease_mob.dm
+++ b/code/modules/antagonists/disease/disease_mob.dm
@@ -110,23 +110,7 @@ the new instance inside the host to be updated to the template's stats.
 /mob/camera/disease/say(message, datum/language/language = null)
 	return
 
-/mob/camera/disease/Hear(message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode, atom/movable/source)
-	. = ..()
-	var/atom/movable/to_follow = speaker
-	if(radio_freq)
-		var/atom/movable/virtualspeaker/V = speaker
-		to_follow = V.source
-	var/link
-	if(to_follow in hosts)
-		link = FOLLOW_LINK(src, to_follow)
-	else
-		link = ""
-	// Create map text prior to modifying message for goonchat
-	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker)))
-		create_chat_message(speaker, message_language, raw_message, spans, message_mode)
-	// Recompose the message, because it's scrambled by default
-	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode, FALSE, source)
-	to_chat(src, "[link] [message]")
+
 
 /mob/camera/disease/Move(NewLoc, Dir = 0)
 	if(freemove)


### PR DESCRIPTION
## Description
Addresses issues with Runechat causing the say verb from working entirely.  This is an emergency hotfix
## Motivation and Context
Appeared to be stable one night, we've observed today, as admins/players play with diseases and imaginary friends, it appears to be causing issues that cause the say verb to break.

## How Has This Been Tested?
Clean compiled, tested on private, code still functional without the modified additional code.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Runechat emergency hotfix, removed imagingary friends and certain diseases from runechat.
/:cl:
