### PR TITLE
Tea fix!!

### DIFF
--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -14,6 +14,7 @@
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/tea/astra)
+	reagents_add = list("teapowder" = 0.05, "vitamin" = 0.04)
 
 /obj/item/reagent_containers/food/snacks/grown/tea
 	seed = /obj/item/seeds/tea
@@ -21,7 +22,6 @@
 	desc = "These aromatic tips of the tea plant can be dried to make tea."
 	icon_state = "tea_aspera_leaves"
 	filling_color = "#008000"
-	grind_results = list("teapowder" = 0)
 	dry_grind = TRUE
 	can_distill = FALSE
 
@@ -33,7 +33,7 @@
 	plantname = "Tea Astra Plant"
 	product = /obj/item/reagent_containers/food/snacks/grown/tea/astra
 	mutatelist = list()
-	reagents_add = list("synaptizine" = 0.1, "vitamin" = 0.04, "teapowder" = 0.1)
+	reagents_add = list("synaptizine" = 0.1, "vitamin" = 0.08, "teapowder" = 0.1)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/tea/astra
@@ -41,8 +41,6 @@
 	name = "Tea Astra tips"
 	icon_state = "tea_astra_leaves"
 	filling_color = "#4582B4"
-	grind_results = list("teapowder" = 0, "salglu_solution" = 0)
-
 
 // Coffee
 /obj/item/seeds/coffee
@@ -61,7 +59,7 @@
 	icon_dead = "coffee-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/coffee/robusta)
-	reagents_add = list("vitamin" = 0.04, "coffeepowder" = 0.1)
+	reagents_add = list("vitamin" = 0.04, "coffeepowder" = 0.05)
 
 /obj/item/reagent_containers/food/snacks/grown/coffee
 	seed = /obj/item/seeds/coffee
@@ -71,7 +69,6 @@
 	filling_color = "#DC143C"
 	bitesize_mod = 2
 	dry_grind = TRUE
-	grind_results = list("coffeepowder" = 0)
 	distill_reagent = "kahlua"
 
 // Coffee Robusta
@@ -83,7 +80,7 @@
 	plantname = "Coffee Robusta Bush"
 	product = /obj/item/reagent_containers/food/snacks/grown/coffee/robusta
 	mutatelist = list()
-	reagents_add = list("ephedrine" = 0.1, "vitamin" = 0.04, "coffeepowder" = 0.1)
+	reagents_add = list("ephedrine" = 0.1, "vitamin" = 0.08, "coffeepowder" = 0.1)
 	rarity = 20
 
 /obj/item/reagent_containers/food/snacks/grown/coffee/robusta
@@ -91,6 +88,5 @@
 	name = "coffee robusta beans"
 	desc = "A handful of dark roasted of beans"
 	icon_state = "coffee_robusta"
-	grind_results = list("coffeepowder" = 3)
 
 /*HRP*/


### PR DESCRIPTION
## Description
The Tea Leave Tips didn't produce teapowder when grinded (`grind_results`). It was because the grinding code for edible items factors in nutrition, which is in turn factored by potency. It makes a lot of sense for wheat, for example, but not for tea because it doesn't give any nutrition!

`/obj/item/reagent_containers/food/snacks/grown/on_grind()
	var/nutriment = reagents.get_reagent_amount("nutriment")
	if(grind_results&&grind_results.len)
		for(var/i in 1 to grind_results.len)
			grind_results[grind_results[i]] = nutriment
		reagents.del_reagent("nutriment")
		reagents.del_reagent("vitamin")` 

So the var/nutriment is multiplied in a way I can't comprehend by `grind_results = list("teapowder" = 0)` but since tea doesn't give nutrition, it multiplies by 0, giving no teapowder.

The alternative I came up with was to give to the seed the `reagents_add = list("vitamin" = 0.04, "teapowder" = 0.05)` proc, so the plants have that inside them, factored by their Potency. When grinded, they will yield vitamin and teapowder.

## Motivation and Context
I like tea maaan. It matters more since the Oasis doesn't have the juice dispenser by default.

## How Has This Been Tested?

Compiles? Yes
Crashes? No
Private server? Runs

## Changelog (necessary)
:cl:
delete: removed `grind_results = list()` from `/obj/item/seeds/tea/astra`, `/obj/item/seeds/coffee` & `/obj/item/seeds/coffee/robusta`
add: gave `reagents_add = list()` to `/obj/item/seeds/tea`
tweak: tweaked the `reagents_add = list()` of `/obj/item/seeds/tea/astra`, `/obj/item/seeds/coffee` & `/obj/item/seeds/coffee/robusta`
/:cl:
