### PR TITLE
Pulse Weapon Tweaks

### DIFF
--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -161,8 +161,8 @@ Head Scribe
 	exp_type = EXP_TYPE_SCRIBE
 
 	loadout_options = list(
-	/datum/outfit/loadout/hsstand, //Needler, pen, and medbeam
-	/datum/outfit/loadout/hspract //AEP7 and hypospray
+	/datum/outfit/loadout/hsstand, //Pulse pistol, and medbeam
+	/datum/outfit/loadout/hspract //Needler and hypospray
 	)
 
 	outfit = /datum/outfit/job/bos/f13headscribe
@@ -188,7 +188,6 @@ Head Scribe
 
 /datum/outfit/loadout/hsstand
 	name = "Medicinal Expert"
-	l_hand = /obj/item/gun/ballistic/revolver/needler
 	backpack_contents = list(
 		/obj/item/gun/energy/ionrifle/carbine=1,
 		/obj/item/stock_parts/cell/ammo/mfc=2,

--- a/code/modules/projectiles/ammunition/energy/special.dm
+++ b/code/modules/projectiles/ammunition/energy/special.dm
@@ -6,7 +6,7 @@
 
 /obj/item/ammo_casing/energy/ion/pistol
 	projectile_type = /obj/item/projectile/ion/weak
-	e_cost = 150
+	e_cost = 50
 	fire_sound = 'sound/f13weapons/pulsepistolfire.ogg'
 
 /obj/item/ammo_casing/energy/declone

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -26,6 +26,7 @@
 	ammo_x_offset = 2
 	flight_x_offset = 18
 	flight_y_offset = 11
+	cell_type = /obj/item/stock_parts/cell/ammo/ec
 
 /obj/item/gun/energy/decloner
 	name = "biological demolecularisor"

--- a/code/modules/projectiles/projectile/energy/misc.dm
+++ b/code/modules/projectiles/projectile/energy/misc.dm
@@ -1,9 +1,9 @@
 /obj/item/projectile/energy/declone
 	name = "FEV stream"
 	icon_state = "declone"
-	damage = 35
+	damage = 30
 	damage_type = CLONE
-	irradiate = 15
+	irradiate = 20
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 
 /obj/item/projectile/energy/dart //ninja throwing dart

--- a/code/modules/projectiles/projectile/special/ion.dm
+++ b/code/modules/projectiles/projectile/special/ion.dm
@@ -13,7 +13,7 @@
 	return TRUE
 
 /obj/item/projectile/ion/weak
-	damage = 20
+	damage = 25
 	armour_penetration = 55
 
 /obj/item/projectile/ion/weak/on_hit(atom/target, blocked = FALSE)


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes that Head Scribe spawns with both a Needler and the pulse pistol

Fixes that pulse pistols used MFC's instead of EC's.

Adjusts the damage of the decloner

Slightly adjusts the damage of the pulse pistol.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
Tested on my server, working appropriately.

## Changelog (necessary)
:cl:
balance: made the decloner a bit more balanced
fix: fixed head scribe spawning with a needler when choosing medicinal expert
fix: fixed pulse pistols using MFC's
/:cl:
