### PR TITLE
Raider Overhaul + New Raider Loadouts

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -348,7 +348,7 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	breakouttime = 70
-	knockdown = 20
+	knockdown = 10
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -348,7 +348,7 @@
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
 	breakouttime = 70
-	knockdown = 10
+	knockdown = 7
 
 /obj/item/restraints/legcuffs/bola/energy //For Security
 	name = "energy bola"

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -347,7 +347,7 @@
 	name = "reinforced bola"
 	desc = "A strong bola, made with a long steel chain. It looks heavy, enough so that it could trip somebody."
 	icon_state = "bola_r"
-	breakouttime = 70
+	breakouttime = 45
 	knockdown = 7
 
 /obj/item/restraints/legcuffs/bola/energy //For Security

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -348,6 +348,7 @@
 	resistance_flags = NONE
 	permeability_coefficient = 0.05 //Thick soles, and covers the ankle
 	pocket_storage_component_path = /datum/component/storage/concrete/pockets/shoes
+	slowdown = -0.05
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "tactical boots"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -206,8 +206,8 @@ Raider
 	suit = /obj/item/clothing/suit/armor/f13/raider
 	head = /obj/item/clothing/head/helmet/f13/raider
 	backpack_contents = list(
-		/obj/item/gun/ballistic/shotgun/automatic/hunting/trail=1,
-		/obj/item/ammo_box/tube/m44=2,
+		/obj/item/gun/ballistic/automatic/mini_uzi=1,
+		/obj/item/ammo_box/magazine/uzim9mm =1,
 		/obj/item/kitchen/knife/combat=1,
 		/obj/item/storage/pill_bottle/dice=1,
 		/obj/item/storage/fancy/cigarettes/cigpack_cannabis=1)

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -119,7 +119,12 @@ Raider
 	/datum/outfit/loadout/raider_blast,
 	/datum/outfit/loadout/raider_sadist,
 	/datum/outfit/loadout/raider_painspike,
-	/datum/outfit/loadout/raider_badlands)
+	/datum/outfit/loadout/raider_badlands,
+	/datum/outfit/loadout/raider_bos,
+	/datum/outfit/loadout/raider_ncr,
+	/datum/outfit/loadout/raider_legion,
+	/datum/outfit/loadout/raider_sheriff,
+	/datum/outfit/loadout/raider_vault)
 
 /datum/outfit/job/wasteland/f13raider
 	name = "Raider"
@@ -175,6 +180,7 @@ Raider
 		/obj/item/restraints/handcuffs=2, \
 		/obj/item/claymore/machete/pipe=1, \
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=1, \
+		/obj/item/reagent_containers/pill/patch/healingpowder=2, \
 		/obj/item/storage/bag/money/small/raider=1)
 
 	suit_store = pick(
@@ -199,31 +205,108 @@ Raider
 	name = "Supa-fly"
 	suit = /obj/item/clothing/suit/armor/f13/raider
 	head = /obj/item/clothing/head/helmet/f13/raider
+	backpack_contents = list(
+		/obj/item/gun/ballistic/shotgun/automatic/hunting/trail=1,
+		/obj/item/ammo_box/tube/m44=2,
+		/obj/item/kitchen/knife/combat=1,
+		/obj/item/storage/pill_bottle/dice=1,
+		/obj/item/storage/fancy/cigarettes/cigpack_cannabis=1)
 
 /datum/outfit/loadout/raider_yankee
 	name = "Yankee"
 	suit = /obj/item/clothing/suit/armor/f13/raider/yankee
 	head = /obj/item/clothing/head/helmet/f13/raider/yankee
+	backpack_contents = list(
+		/obj/item/twohanded/baseball/spiked=1,
+		/obj/item/gun/ballistic/shotgun/remington/scoped=1,
+		/obj/item/ammo_box/a308=2,
+		/obj/item/storage/fancy/cigarettes/cigpack_cannabis=1,
+		/obj/item/megaphone=1)
+
 
 /datum/outfit/loadout/raider_blast
 	name = "Blastmaster"
 	suit = /obj/item/clothing/suit/armor/f13/raider/blastmaster
 	head = /obj/item/clothing/head/helmet/f13/raider/blastmaster
+	backpack_contents = list(
+		/obj/item/twohanded/fireaxe=1,
+		/obj/item/gun/ballistic/revolver/colt6250=1,
+		/obj/item/grenade/iedcasing=2,
+		/obj/item/ammo_box/l10mm=2)
 
 /datum/outfit/loadout/raider_sadist
 	name = "Sadist"
 	suit = /obj/item/clothing/suit/armor/f13/raider/sadist
 	head = /obj/item/clothing/head/helmet/f13/raider/arclight
+	backpack_contents = list(
+		/obj/item/gun/ballistic/revolver/colt357=1,
+		/obj/item/ammo_box/a357=2,
+		/obj/item/clothing/mask/gas/explorer/folded=1,
+		/obj/item/throwing_star/spear=1,
+		/obj/item/grenade/chem_grenade/teargas=1,
+		/obj/item/dildo=1)
 
 /datum/outfit/loadout/raider_badlands
 	name = "Badlands"
 	suit = /obj/item/clothing/suit/armor/f13/badlands
 	head = /obj/item/clothing/head/helmet/f13/fiend
+	backpack_contents = list(
+		/obj/item/restraints/legcuffs/bola/tactical=1,
+		/obj/item/gun/ballistic/revolver/police=1,
+		/obj/item/ammo_box/a357=1,
+		/obj/item/reagent_containers/hypospray/medipen/psycho=1,
+		/obj/item/reagent_containers/pill/patch/turbo=1)
 
 /datum/outfit/loadout/raider_painspike
 	name = "Painspike"
 	suit = /obj/item/clothing/suit/armor/f13/raider/painspike
 	head = /obj/item/clothing/head/helmet/f13/raider/psychotic
+	backpack_contents = list(
+		/obj/item/gun/ballistic/shotgun/trench=1,
+		/obj/item/storage/box/lethalshot=1,
+		/obj/item/storage/box/beanbag=1,
+		/obj/item/claymore/machete/pipe/tireiron=1,
+		/obj/item/claymore/machete/pipe/pan=1,
+		/obj/item/reagent_containers/spray/cyborg_lube=1)
+
+/datum/outfit/loadout/raider_bos
+	name = "Brotherhood Exile"
+	suit = /obj/item/clothing/suit/armor/f13/combat/brotherhood
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/stock_parts/cell/ammo/ec=2)
+
+/datum/outfit/loadout/raider_ncr
+	name = "NCR Deserter"
+	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/marksman/servicerifle=1,
+		/obj/item/ammo_box/magazine/m556/rifle=2)
+
+/datum/outfit/loadout/raider_legion
+	name = "Punished Legionnaire"
+	suit = /obj/item/clothing/suit/armor/f13/legion/prime
+	backpack_contents = list(
+		/obj/item/claymore/machete/gladius=1,
+		/obj/item/restraints/legcuffs/bola=2,
+		/obj/item/storage/backpack/spearquiver=1)
+
+/datum/outfit/loadout/raider_sheriff
+	name = "Dark Sheriff"
+	suit = /obj/item/clothing/suit/armor/vest/leather
+	uniform = /obj/item/clothing/under/syndicate/tacticool
+	backpack_contents = list(
+		/obj/item/gun/ballistic/revolver/m29/alt=1,
+		/obj/item/ammo_box/m44=2)
+
+/datum/outfit/loadout/raider_vault
+	name = "Vault Outcast"
+	suit = /obj/item/clothing/suit/armor/f13/leatherarmor
+	uniform = /obj/item/clothing/under/f13/vault
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/ammo_box/magazine/m10mm_adv=2)
+
 
 /datum/outfit/loadout/raider_metal
 	name = "Metal Raider"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -272,6 +272,7 @@ Raider
 /datum/outfit/loadout/raider_bos
 	name = "Brotherhood Exile"
 	suit = /obj/item/clothing/suit/armor/f13/combat/brotherhood
+	id = /obj/item/card/id/rusted/brokenholodog
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol=1,
 		/obj/item/stock_parts/cell/ammo/ec=2)
@@ -279,6 +280,7 @@ Raider
 /datum/outfit/loadout/raider_ncr
 	name = "NCR Deserter"
 	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
+	id = /obj/item/card/id/rusted
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/marksman/servicerifle=1,
 		/obj/item/ammo_box/magazine/m556/rifle=2)
@@ -286,6 +288,7 @@ Raider
 /datum/outfit/loadout/raider_legion
 	name = "Punished Legionnaire"
 	suit = /obj/item/clothing/suit/armor/f13/legion/prime
+	id = /obj/item/card/id/rusted/rustedmedallion
 	backpack_contents = list(
 		/obj/item/claymore/machete/gladius=1,
 		/obj/item/restraints/legcuffs/bola=2,
@@ -303,6 +306,7 @@ Raider
 	name = "Vault Outcast"
 	suit = /obj/item/clothing/suit/armor/f13/leatherarmor
 	uniform = /obj/item/clothing/under/f13/vault
+	id = /obj/item/card/id/rusted/fadedvaultid
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		/obj/item/ammo_box/magazine/m10mm_adv=2)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1498,6 +1498,7 @@
 #include "code\modules\clothing\under\jobs\medsci.dm"
 #include "code\modules\clothing\under\jobs\security.dm"
 #include "code\modules\crafting\craft.dm"
+#include "code\modules\crafting\forge.dm"
 #include "code\modules\crafting\guncrafting.dm"
 #include "code\modules\crafting\items.dm"
 #include "code\modules\crafting\recipes.dm"


### PR DESCRIPTION
## Description
Changes the load outs all raiders, giving them a bit more of a startup viability. along with new items (weapon, utility, etc.) That are themed around the armors of each raider type, and the faction raiders too.

Changes combat boots and reinforced bolas.  Combat boots now give a minimal speed bost while worn.

## Motivation and Context
It was agreed raiders needed an overhaul and there was a request for factional raiders, so it's done now.

## How Has This Been Tested?
Clean compiled, checked to ensure the load outs were right.

## Screenshots (if appropriate):
![RAIDUR](https://user-images.githubusercontent.com/58003498/84341833-17138c80-ab72-11ea-8bea-3a3f02d5a810.png)

## Changelog (necessary)
:cl:
Added loadout variety for normal faction roles
Added 5 Faction-Raider loadouts that are themed to what their origin was before their fall from grace.
Added 2 healing powders to raider load out to encourage prisoner capture/allow the ability to.
Reinforced bola knockdown reduce ~70 percent, time to remove that of a normal bola now
Combat boots speed increase
/:cl:
