### PR TITLE
Raider loadout outfit update/Overhaul Part 2.  Runechat feature update

### DIFF
--- a/code/modules/clothing/head/f13.dm
+++ b/code/modules/clothing/head/f13.dm
@@ -73,6 +73,14 @@
 	armor = list("melee" = 40, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
 	flags_inv = HIDEEARS|HIDEHAIR
 
+/obj/item/clothing/head/helmet/f13/fiend_reinforced
+	name = "reinforced fiend helmet"
+	desc = "A leather cap cobbled together adorned with a bighorner skull, perfect for any drug-fueled frenzy. This helmet has been reinforced with metal plates under its skull"
+	icon_state = "fiend"
+	item_state = "fiend"
+	armor = list("melee" = 45, "bullet" = 30, "laser" = 20, "energy" = 10, "bomb" = 16, "bio" = 20, "rad" = 0, "fire" = 50, "acid" = 0)
+	flags_inv = HIDEEARS|HIDEHAIR
+
 /obj/item/clothing/head/helmet/f13/vaquerohat
 	name = "vaquero hat"
 	desc = "An old sombrero worn by Vaqueros to keep off the harsh sun."

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -356,7 +356,7 @@
 
 /obj/item/clothing/suit/armor/f13/raider/reinforced
 	name = "reinforced supa-fly raider armor"
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 35, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/raider/sadist
 	name = "sadist raider armor"
@@ -365,7 +365,7 @@
 /obj/item/clothing/suit/armor/f13/raider/sadist/reinforced
 	name = "reinforced sadist raider armor"
 	icon_state = "sadist"
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 35, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/raider/blastmaster
 	name = "blastmaster raider armor"
@@ -375,7 +375,7 @@
 
 /obj/item/clothing/suit/armor/f13/raider/blastmaster/reinforced
 	name = "reinforced blastmaster raider armor"
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 35, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/raider/yankee
 	name = "yankee raider armor"
@@ -386,7 +386,7 @@
 
 /obj/item/clothing/suit/armor/f13/raider/yankee/reinforced
 	name = "reinforced yankee raider armor"
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 35, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/badlands
 	name = "badlands raider armor"
@@ -395,7 +395,7 @@
 
 /obj/item/clothing/suit/armor/f13/badlands/reinforced
 	name = "reinforced badlands raider armor"
-	armor = list("melee" = 40, "bullet" = 40, "laser" = 30, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 40, "bullet" = 40, "laser" = 35, "energy" = 25, "bomb" = 35, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 30)
 
 /obj/item/clothing/suit/armor/f13/raider/painspike
 	name = "painspike raider armor"

--- a/code/modules/crafting/tailoring.dm
+++ b/code/modules/crafting/tailoring.dm
@@ -84,11 +84,134 @@
 	category = CAT_CLOTHING
 	subcategory = CAT_CLOTHING
 
-/datum/crafting_recipe/combat_coat
-	name = "combat coat"
+/datum/crafting_recipe/supaflyhelm_reinforced
+	name = "reinforced supafly helmet"
+	result = /obj/item/clothing/head/helmet/f13/raider/reinforced
+	reqs = list(/obj/item/clothing/head/helmet/f13/raider = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/supafly_reinforced
+	name = "reinforced supafly armor"
+	result = /obj/item/clothing/suit/armor/f13/raider/reinforced
+	reqs = list(/obj/item/clothing/suit/armor/f13/raider = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/yankeehelm_reinforced
+	name = "reinforced yankee helmet"
+	result = /obj/item/clothing/head/helmet/f13/raider/yankee/reinforced
+	reqs = list(/obj/item/clothing/head/helmet/f13/raider/yankee = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/yankee_reinforced
+	name = "reinforced yankee armor"
+	result = /obj/item/clothing/suit/armor/f13/raider/yankee/reinforced
+	reqs = list(/obj/item/clothing/suit/armor/f13/raider/yankee = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/blasterhelm_reinforced
+	name = "reinforced blaster helmet"
+	result = /obj/item/clothing/head/helmet/f13/raider/blastmaster/reinforced
+	reqs = list(/obj/item/clothing/head/helmet/f13/raider/blastmaster = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/blaster_reinforced
+	name = "reinforced blaster armor"
 	result = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
-	reqs = list(/obj/item/clothing/suit/armor/f13/leather_jacket/combat = 1,
-				/obj/item/stack/sheet/animalhide/deathclaw = 1)
+	reqs = list(/obj/item/clothing/suit/armor/f13/raider/blastmaster/reinforced = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/sadisthelm_reinforced
+	name = "reinforced sadist helmet"
+	result = /obj/item/clothing/head/helmet/f13/raider/arclight/reinforced
+	reqs = list(/obj/item/clothing/head/helmet/f13/raider/arclight = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/sadist_reinforced
+	name = "reinforced sadist armor"
+	result = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
+	reqs = list(/obj/item/clothing/suit/armor/f13/raider/sadist/reinforced = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/fiendshelm_reinforced
+	name = "reinforced fiend helmet"
+	result = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
+	reqs = list(/obj/item/clothing/head/helmet/f13/fiend = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/badlands_reinforced
+	name = "reinforced badlands armor"
+	result = /obj/item/clothing/suit/armor/f13/badlands/reinforced
+	reqs = list(/obj/item/clothing/suit/armor/f13/badlands = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+
+/datum/crafting_recipe/painspikehelm_reinforced
+	name = "reinforced painspike helmet"
+	result = /obj/item/clothing/head/helmet/f13/raider/psychotic/reinforced
+	reqs = list(/obj/item/clothing/head/helmet/f13/raider/psychotic = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 60
+	category = CAT_CLOTHING
+	subcategory = CAT_CLOTHING
+
+/datum/crafting_recipe/painspike_reinforced
+	name = "reinforced painspike armor"
+	result = /obj/item/clothing/suit/armor/f13/raider/painspike/reinforced
+	reqs = list(/obj/item/clothing/suit/armor/f13/raider/painspike = 1,
+				/obj/item/stack/crafting/goodparts = 2,
+				/obj/item/stack/sheet/metal = 5)
 	tools = list(TOOL_WORKBENCH)
 	time = 60
 	category = CAT_CLOTHING

--- a/code/modules/fallout/misc/gang_items.dm
+++ b/code/modules/fallout/misc/gang_items.dm
@@ -183,7 +183,7 @@
 /datum/gang_item/equipment/emp
 	name = "EMP Grenade"
 	id = "EMP"
-	cost = 130
+	cost = 95
 	item_path = /obj/item/grenade/empgrenade
 
 /datum/gang_item/equipment/necklace

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -124,7 +124,8 @@ Raider
 	/datum/outfit/loadout/raider_ncr,
 	/datum/outfit/loadout/raider_legion,
 	/datum/outfit/loadout/raider_sheriff,
-	/datum/outfit/loadout/raider_vault)
+	/datum/outfit/loadout/raider_vault,
+	/datum/outfit/loadout/raider_mafia)
 
 /datum/outfit/job/wasteland/f13raider
 	name = "Raider"
@@ -300,9 +301,23 @@ Raider
 	name = "Dark Sheriff"
 	suit = /obj/item/clothing/suit/armor/vest/leather
 	uniform = /obj/item/clothing/under/syndicate/tacticool
+	head = /obj/item/clothing/head/helmet/f13/brahmincowboyhat
 	backpack_contents = list(
 		/obj/item/gun/ballistic/revolver/m29/alt=1,
-		/obj/item/ammo_box/m44=2)
+		/obj/item/ammo_box/m44=2,
+		/obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy=1,
+		/obj/item/ammo_box/tube/a357=2)
+
+/datum/outfit/loadout/raider_mafia
+    name = "Town Mafia"
+    suit = /obj/item/clothing/suit/armor/f13/leather_jacket
+    uniform = /obj/item/clothing/under/f13/bennys
+    glasses = /obj/item/clothing/glasses/sunglasses
+    shoes =/obj/item/clothing/shoes/f13/fancy
+    backpack_contents = list(
+        /obj/item/gun/ballistic/automatic/pistol/ninemil/maria=1,
+        /obj/item/ammo_box/magazine/m9mm=2,
+        /obj/item/toy/cards/deck=1)
 
 /datum/outfit/loadout/raider_vault
 	name = "Vault Outcast"

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -271,7 +271,7 @@ Raider
 
 /datum/outfit/loadout/raider_bos
 	name = "Brotherhood Exile"
-	suit = /obj/item/clothing/suit/armor/f13/combat/brotherhood
+	suit = /obj/item/clothing/suit/armor/f13/exile/bosexile
 	id = /obj/item/card/id/rusted/brokenholodog
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol=1,

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -279,7 +279,8 @@ Raider
 
 /datum/outfit/loadout/raider_ncr
 	name = "NCR Deserter"
-	suit = /obj/item/clothing/suit/armor/f13/ncrarmor/mantle
+	suit = /obj/item/clothing/suit/armor/f13/exile
+	uniform = /obj/item/clothing/under/f13/exile
 	id = /obj/item/card/id/rusted
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/marksman/servicerifle=1,
@@ -287,7 +288,8 @@ Raider
 
 /datum/outfit/loadout/raider_legion
 	name = "Punished Legionnaire"
-	suit = /obj/item/clothing/suit/armor/f13/legion/prime
+	suit = /obj/item/clothing/suit/armor/f13/exile/legexile
+	uniform = /obj/item/clothing/under/f13/exile/legion
 	id = /obj/item/card/id/rusted/rustedmedallion
 	backpack_contents = list(
 		/obj/item/claymore/machete/gladius=1,
@@ -305,7 +307,7 @@ Raider
 /datum/outfit/loadout/raider_vault
 	name = "Vault Outcast"
 	suit = /obj/item/clothing/suit/armor/f13/leatherarmor
-	uniform = /obj/item/clothing/under/f13/vault
+	uniform = /obj/item/clothing/under/f13/exile/vault
 	id = /obj/item/card/id/rusted/fadedvaultid
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,

--- a/code/modules/mob/dead/observer/say.dm
+++ b/code/modules/mob/dead/observer/say.dm
@@ -33,6 +33,9 @@
 		else
 			to_follow = V.source
 	var/link = FOLLOW_LINK(src, to_follow)
+		// Create map text prior to modifying message for goonchat //Skyrat change
+	if (client?.prefs.chat_on_map && (client.prefs.see_chat_non_mob || ismob(speaker))) //Skyrat change
+		create_chat_message(speaker, message_language, raw_message, spans, message_mode) //Skyrat change
 	// Recompose the message, because it's scrambled by default
 	message = compose_message(speaker, message_language, raw_message, radio_freq, spans, message_mode)
 	to_chat(src, "[link] [message]")


### PR DESCRIPTION
## Description
Changed loadout for NCR, Legion, Vault, and BoS raiders that gives them an update outfit to go with their status. Added reinforced fiend helmet to go with Badlands armor.  Reinforced raider armors can be crafted with a semi-precious resource.  Minor adjustment to prices in gangtool,

Allows runechat to be seen by ghost.

## Motivation and Context
Continuing on the runechat milestone

## How Has This Been Tested?
Compiled and tested to be operable on private server.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Updated observer runechat side so they can see it while a ghost.
NCR, Legion, Vault, BoS raider outfits added, changed in loadout.
Price for EMPs adjusted from gangtool
Added Fiend Reinforced Helmet
Armor crafting for raider sets

/:cl:
