### PR TITLE
Hotfix for followers update

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -498,6 +498,12 @@ update_label("John Doe", "Clowny")
 	item_state = "silver"
 	id_type = "ambassador's permit"
 
+/obj/item/card/id/dogtag/ncradmin
+	name = "Administrators ID"
+	desc = "An silver encrusted admins ID in a plastic holder."
+	icon_state = "silver"
+	item_state = "silver"
+
 /obj/item/card/id/dogtag/ncrtrooper
 	name = "trooper's tags"
 	desc = "A dog tag proving enlistment."

--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -89,11 +89,8 @@ Practitioner
 	backpack = /obj/item/storage/backpack/explorer
 	uniform = /obj/item/clothing/under/f13/followers
 	backpack_contents = list(
-		/obj/item/storage/firstaid/tactical=1,
-		/obj/item/storage/firstaid/regular=1,
-		/obj/item/storage/firstaid/toxin=1,
-		/obj/item/defibrillator/compact/loaded=1
-		)
+		/obj/item/defibrillator/compact/loaded)
+
 
 /datum/outfit/loadout/chemist
 	name = "Chemist"
@@ -105,6 +102,7 @@ Practitioner
 
 /datum/outfit/loadout/physician
 	name = "Physician"
+	l_hand = /obj/item/storage/firstaid/tactical
 	backpack_contents = list(
 		/obj/item/book/granter/trait/chemistry=1,
 		/obj/item/reagent_containers/medspray/synthflesh=2,

--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -557,9 +557,9 @@ Recruit
 	outfit = /datum/outfit/job/ncr/f13ncradmin
 
 /datum/outfit/job/ncr/f13ncradmin
-	name = "NCR Assistant"
-	jobtype = /datum/job/ncr/f13recruit
-	id = 			/obj/item/card/id/dogtag/ncrtrooper
+	name = "NCR Administrator"
+	jobtype = /datum/job/ncr/f13ncradmin
+	id = 			/obj/item/card/id/dogtag/ncradmin
 	uniform =  		/obj/item/clothing/under/suit_jacket/tan
 	glasses =		/obj/item/clothing/glasses/sunglasses
 	shoes = 		/obj/item/clothing/shoes/f13/fancy
@@ -624,7 +624,8 @@ Recruit
 		/obj/item/reagent_containers/glass/bucket=1,
 		/obj/item/cultivator=1,
 		/obj/item/shovel/spade=1,
-		/obj/item/reagent_containers/glass/bottle/nutrient/rh=2
+		/obj/item/reagent_containers/glass/bottle/nutrient/rh=2,
+		/obj/item/hatchet=1
 		)
 
 /datum/outfit/loadout/mechanic

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -117,7 +117,7 @@ Detective
 	uniform = /obj/item/clothing/under/f13/detectivealt
 	head = /obj/item/clothing/head/f13/det_hat_alt
 	shoes =  /obj/item/clothing/shoes/laceup
-	id = /obj/item/card/id
+	id = /obj/item/card/id/silver
 	backpack = /obj/item/storage/backpack/satchel/explorer
 	satchel = /obj/item/storage/backpack/satchel/explorer
 	suit_store = /obj/item/gun/ballistic/revolver/police


### PR DESCRIPTION
## Description
Addresses issues with IDs for detective, NCR admin.  Adds one forgotten item to share cropper and makes the Doctor loadouts work.

## Motivation and Context
Bugfix

## How Has This Been Tested?
Compiled and tested

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Fixed bugs with followers roles, fixed loadouts, made ID for NCR admin, and detective, added item to sharecropper.
/:cl:
