### PR TITLE
Rune Chat Emergency Hotfix

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -254,7 +254,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/list/dead_away = list()
 	var/list/yellareas	//CIT CHANGE - adds the ability for yelling to penetrate walls and echo throughout areas
 	if(!eavesdrop_range && say_test(message) == "2")	//CIT CHANGE - ditto
-		yellareas = get_areas_in_range(message_range*0.5, source)	//CIT CHANGE - ditto
+		yellareas = get_areas_in_range(message_range*0, source)	//CIT CHANGE - ditto
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(M.stat != DEAD) //not dead, not important
@@ -302,7 +302,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			speech_bubble_recipients.Add(M.client)
 	var/image/I = image('icons/mob/talk.dmi', src, "[bubble_type][say_test(message)]", FLY_LAYER)
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_speechbubble, I, speech_bubble_recipients, 30) //skyrat-edit 
+	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_speechbubble, I, speech_bubble_recipients, 30) //skyrat-edit
 
 /mob/proc/binarycheck()
 	return FALSE
@@ -438,7 +438,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	var/list/dead_away = list()
 	var/list/yellareas	//CIT CHANGE - adds the ability for yelling to penetrate walls and echo throughout areas
 	if(!eavesdrop_range && say_test(message) == "2")	//CIT CHANGE - ditto
-		yellareas = get_areas_in_range(message_range*0.5, source)	//CIT CHANGE - ditto
+		yellareas = get_areas_in_range(message_range*0, source)	//CIT CHANGE - ditto
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(M.stat != DEAD) //not dead, not important
@@ -486,7 +486,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			speech_bubble_recipients.Add(M.client)
 	var/image/I = image('icons/mob/talk.dmi', src, "[bubble_type][say_test(message)]", FLY_LAYER)
 	I.appearance_flags = APPEARANCE_UI_IGNORE_ALPHA
-	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_speechbubble, I, speech_bubble_recipients, 30) //skyrat-edit 
+	INVOKE_ASYNC(GLOBAL_PROC, /.proc/animate_speechbubble, I, speech_bubble_recipients, 30) //skyrat-edit
 
 /proc/animate_speechbubble(image/I, list/show_to, duration)
 	var/matrix/M = matrix()
@@ -500,4 +500,4 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	animate(I, alpha = 0, time = 5, easing = EASE_IN)
 	spawn(20)
 	for(var/client/C in show_to)
-		C.images -= I 
+		C.images -= I

--- a/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
+++ b/code/modules/mob/living/simple_animal/friendly/farm_animals.dm
@@ -8,7 +8,7 @@
 	speak_emote = list("brays")
 	emote_hear = list("brays.")
 	emote_see = list("shakes its head.", "stamps a foot.", "glares around.")
-	speak_chance = 1
+	speak_chance = 0
 	turns_per_move = 5
 	see_in_dark = 6
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 4)
@@ -113,7 +113,7 @@
 	speak_emote = list("moos","moos hauntingly")
 	emote_hear = list("brays.")
 	emote_see = list("shakes its head.")
-	speak_chance = 1
+	speak_chance = 0
 	turns_per_move = 5
 	see_in_dark = 6
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 6)
@@ -224,7 +224,7 @@
 	emote_hear = list("cheeps.")
 	emote_see = list("pecks at the ground.","flaps its tiny wings.")
 	density = FALSE
-	speak_chance = 2
+	speak_chance = 0
 	turns_per_move = 2
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 1)
 	response_help  = "pets"
@@ -272,7 +272,7 @@
 	emote_hear = list("clucks.")
 	emote_see = list("pecks at the ground.","flaps its wings viciously.")
 	density = FALSE
-	speak_chance = 2
+	speak_chance = 0
 	turns_per_move = 3
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2)
 	response_help  = "pets"
@@ -386,7 +386,7 @@
 	young_type = /mob/living/simple_animal/cow/brahmin/calf
 	emote_hear = list("brays.")
 	var/obj/item/inventory_back
-	speak_chance = 0.4
+	speak_chance = 0
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 4, /obj/item/reagent_containers/food/snacks/rawbrahminliver = 1, /obj/item/reagent_containers/food/snacks/rawbrahmintongue = 2, /obj/item/stack/sheet/animalhide/brahmin = 3)
 
 /mob/living/simple_animal/hostile/retaliate/goat/bighorn
@@ -401,7 +401,7 @@
 	speak_emote = list("brays")
 	emote_hear = list("brays.")
 	emote_see = list("shakes its head.", "stamps a foot.", "glares around.", "grunts.")
-	speak_chance = 1
+	speak_chance = 0
 	turns_per_move = 5
 	see_in_dark = 6
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 6, /obj/item/stack/sheet/sinew = 3, /obj/item/stack/sheet/bone = 4)

--- a/code/modules/mob/living/simple_animal/hostile/deathclaw.dm
+++ b/code/modules/mob/living/simple_animal/hostile/deathclaw.dm
@@ -15,7 +15,7 @@
 	speak_emote = list("growls", "roars")
 	emote_hear = list("grumbles.","grawls.")
 	emote_taunt = list("stares ferociously", "stomps")
-	speak_chance = 10
+	speak_chance = 0
 	taunt_chance = 25
 	speed = -1
 	see_in_dark = 8


### PR DESCRIPTION
Alright no fancy formatting here it goes as this is important and needs to be understood for posterity.

So when we did the FULL backport of Runechat yesterday, we didn't test it with others, but only that chat worked for US!  Well, due to that we ran into two issues, yelling from ALL mobs could be heard from EVERYWHERE, including players yelling.  This addresses that issue, below, I will show the culprit line.

`	yellareas = get_areas_in_range(message_range*0.5, source)	//CIT CHANGE - ditto`

Changing the 0.5 to 0 seems to remedy the issue.  Now why is this happening?  On citadel, skyrat, and other modern TG code bases, you can HEAR yelling and exclaims through the walls.  On our server, that doesn't exist, so -expanding- a chat range beyond 0 is like having an eternal echo. as there's nothing in the code to drown/dilute code out.

So then the other issue, mobs speak heard.  This was remedied by removing mobs speak chance, but leaving the lines in place.  This is more so a band-aid.  It only seems to affect simple mobs, therefore, no long any lines from deathclaws and so on for the time being until we can figure it out.