### PR TITLE
NCR Exile Sprite Bugfix / Storage container space reduction / Baseball bat recipe re-added

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -28,7 +28,7 @@
 	var/dense_when_open = FALSE //if it's dense when open or not
 	var/max_mob_size = MOB_SIZE_HUMAN //Biggest mob_size accepted by the container
 	var/mob_storage_capacity = 3 // how many human sized mob/living can fit together inside a closet.
-	var/storage_capacity = 30 //This is so that someone can't pack hundreds of items in a locker/crate then open it in a populated area to crash clients.
+	var/storage_capacity = 6 //This is so that someone can't pack hundreds of items in a locker/crate then open it in a populated area to crash clients.
 	var/cutting_tool = /obj/item/weldingtool
 	var/open_sound = 'sound/machines/click.ogg'
 	var/close_sound = 'sound/machines/click.ogg'

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1771,6 +1771,16 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
+/datum/crafting_recipe/baseballbat
+	name = "baseball bat"
+	result = /obj/item/twohanded/baseball
+	time = 80
+	reqs = list(/obj/item/stack/sheet/mineral/wood=10,
+				/obj/item/stack/sheet/metal = 1)
+	tools = list(TOOL_WORKBENCH)
+	category = CAT_WEAPONRY
+	subcategory = CAT_WEAPON
+
 /datum/crafting_recipe/baseballspiked
 	name = "spiked baseball bat"
 	result = /obj/item/twohanded/baseball/spiked
@@ -1977,7 +1987,7 @@
 	tools = list(TOOL_WORKBENCH)
 	category = CAT_PRIMAL
 	subcategory = CAT_TRIBAL
-  
+
 //BOTTLING
 
 /datum/crafting_recipe/bottler

--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -316,7 +316,7 @@ Raider
 
 /datum/outfit/loadout/raider_ncr
 	name = "NCR Deserter"
-	suit = /obj/item/clothing/suit/armor/f13/exile
+	suit = /obj/item/clothing/suit/armor/f13/exile/ncrexile
 	uniform = /obj/item/clothing/under/f13/exile
 	id = /obj/item/card/id/rusted
 	backpack_contents = list(


### PR DESCRIPTION
Fixes the issue with the NCR exile armor not having the correct sprite. By community demand, storage devices (bins, closets, etc). Have had their overall capacity reduced.

Change Log: Corrects the file path to the right one for NCR exile armor (hotfix)
Reduces storage container capacities from 30 to 6
Readded the baseball bat recipe