### PR TITLE
log attacking locked doors (melee only atm)

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -214,6 +214,8 @@
 	else if(!(I.item_flags & NOBLUDGEON) && user.a_intent != INTENT_HARM)
 		try_to_activate_door(user)
 		return TRUE
+	if(Lock)
+		add_logs(user, src, "attacked", src)
 	return ..()
 
 /obj/machinery/door/run_obj_armor(damage_amount, damage_type, damage_flag = 0, attack_dir)

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -175,6 +175,8 @@
 			deconstruct(TRUE)
 	else if(user.a_intent != INTENT_HARM)
 		return attack_hand(user)
+	if(Lock)
+		add_logs(user, src, "attacked", src)
 	else
 		return ..()
 

--- a/code/modules/fallout/obj/structures/simple_door.dm
+++ b/code/modules/fallout/obj/structures/simple_door.dm
@@ -176,6 +176,8 @@
 		else
 			return padlock.check_key(I,user)
 	if(user.a_intent == INTENT_HARM)
+		if(padlock)
+			add_logs(user, src, "attacked", src)
 		return ..()
 	attack_hand(user)
 


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
adds attacking locked doors to the attack logs
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
helps admins/staff deal with people who break into homes that are locked (at least through the door)

also, requested:
Mae/Artemis(Mikierpg)
"Okay, how hard would it be to make attacking doors give attack logs? Because fuck we need that.
Because rn i cannot figure out which side is telling the truth because of a circumspect situation.
it will also make it so when people break into places and rob them so much easier to figure out."
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
compiled, no issues.
tested locally
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: Added attack log to locked doors
/:cl:
