### PR TITLE
Energy/BOS Updates

### DIFF
--- a/code/__DEFINES/jobs.dm
+++ b/code/__DEFINES/jobs.dm
@@ -92,6 +92,7 @@
 #define F13SENIORSCRIBE (1<<8)
 #define F13SCRIBE		(1<<9)
 #define F13INITIATE		(1<<10)
+#define F13OFFDUTYBOS	(1<<11)
 
 #define DEN				(1<<6)
 

--- a/code/game/machinery/cell_charger.dm
+++ b/code/game/machinery/cell_charger.dm
@@ -29,7 +29,7 @@
 		to_chat(user, "Current charge: [round(charging.percent(), 1)]%.")
 
 /obj/machinery/cell_charger/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/stock_parts/cell) && !panel_open)
+	if(istype(W, /obj/item/stock_parts/cell) && !panel_open && !istype(W, /obj/item/stock_parts/cell/ammo))
 		if(stat & BROKEN)
 			to_chat(user, "<span class='warning'>[src] is broken!</span>")
 			return

--- a/code/game/machinery/recharger.dm
+++ b/code/game/machinery/recharger.dm
@@ -11,7 +11,6 @@
 	var/recharge_coeff = 1
 
 	var/static/list/allowed_devices = typecacheof(list(
-		/obj/item/gun/energy,
 		/obj/item/melee/baton,
 		/obj/item/ammo_box/magazine/recharge,
 		/obj/item/modular_computer))

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -218,6 +218,36 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
+/datum/crafting_recipe/ec
+	name = "Small Energy Cell"
+	result = /obj/item/stock_parts/cell/ammo/ec
+	reqs = list(/obj/item/stack/sheet/metal = 1, /obj/item/stock_parts/cell=2)
+	traits = list(TRAIT_GUNSMITH_TWO)
+	tools = list(TOOL_WORKBENCH, TOOL_GUNTIER2)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/mfc
+	name = "Microfusion Cell"
+	result = /obj/item/stock_parts/cell/ammo/mfc
+	reqs = list(/obj/item/stock_parts/capacitor=1, /obj/item/stock_parts/cell/ammo/ec=2)
+	traits = list(TRAIT_GUNSMITH_THREE)
+	tools = list(TOOL_AWORKBENCH, TOOL_GUNTIER3)
+	time = 20
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
+/datum/crafting_recipe/ecp
+	name = "Electron Charge Pack"
+	result = /obj/item/stock_parts/cell/ammo/mfc
+	reqs = list(/obj/item/stock_parts/capacitor=2, /obj/item/stock_parts/cell/ammo/mfc=2)
+	traits = list(TRAIT_GUNSMITH_FOUR)
+	tools = list(TOOL_AWORKBENCH, TOOL_GUNTIER4)
+	time = 30
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
 /datum/crafting_recipe/speedloader10mm
 	name = "empty speed loader (10mm)"
 	result = /obj/item/ammo_box/l10mm/empty

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -19,7 +19,6 @@ Main doors: ACCESS_CAPTAIN 20
 	uniform =		/obj/item/clothing/under/syndicate/brotherhood
 	shoes = /obj/item/clothing/shoes/combat/swat
 	gloves = /obj/item/clothing/gloves/combat
-	glasses = /obj/item/clothing/glasses/night
 	id = /obj/item/card/id/dogtag
 
 /datum/outfit/job/bos/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
@@ -93,6 +92,7 @@ Sentinel
 	loadout_options = list(
 	/datum/outfit/loadout/sentstand, //Tribeam laser and 10mm pistol
 	/datum/outfit/loadout/sentvet, //Pulse rifle and AEP7
+	/datum/outfit/loadout/sentheavy //Gatling laser
 	)
 
 	outfit = /datum/outfit/job/bos/f13sentinel
@@ -141,6 +141,13 @@ Sentinel
 		/obj/item/ammo_box/magazine/m10mm_adv=2,
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
 		)
+
+/datum/outfit/loadout/sentheavy
+	name = "Heavy Sentinel"
+	backpack_contents = list(
+		/obj/item/minigunpack=1,
+		)
+
 
 /*
 Head Scribe
@@ -755,4 +762,173 @@ Initiate
 		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
 		/obj/item/book/granter/trait/chemistry=1,
 		/obj/item/clothing/accessory/bos/initiateS=1
+		)
+
+/*
+Off-Duty
+*/
+
+/datum/job/bos/f13offdutybos
+	title = "Off-Duty"
+	flag = F13OFFDUTYBOS
+	faction = "BOS"
+	total_positions = 8
+	spawn_positions = 8
+	description = "Whether operating in disguise or simply enjoying time from the off-shift, you are still a member of the Brotherhood and must abide by the Codex and follow the orders of your superiors. That being said, while off-duty your orders do not take precedence and you should resist issuing them when another of your rank is currently on duty, and if one does not exist, commit to going on-duty. You have a duty to safeguard what equipment you are given, especially your holotags. Ideally, you should be paired with one or more fellow off-duty members; and you would know where the bunker in the region is."
+	forbids = "The Brotherhood of Steel Forbids: Unethical human experimentation. Violence beyond what is needed to accomplish Brotherhood goals."
+	enforces = "The Brotherhood of Steel Expects: Obeying the Chain That - Binds your direct superior. Collection and safeguarding of technology from the wasteland. Experimentation and research."
+	supervisors = "your superior rank."
+	selection_color = "#95a5a6"
+	exp_requirements = 1800
+	exp_type = EXP_TYPE_CREW
+
+	loadout_options = list(
+	/datum/outfit/loadout/offa, //Junior Knight
+	/datum/outfit/loadout/offb, //Knight
+	/datum/outfit/loadout/offc, //Senior Knight
+	/datum/outfit/loadout/offd, //Knight-Captain
+	/datum/outfit/loadout/offe, //Junior Scribe
+	/datum/outfit/loadout/offf, //Scribe
+	/datum/outfit/loadout/offg, //Senior Scribe
+	/datum/outfit/loadout/offh, //Head Scribe
+	/datum/outfit/loadout/offi, //Junior Paladin
+	/datum/outfit/loadout/offj, //Paladin
+	/datum/outfit/loadout/offk, //Senior Paladin
+	/datum/outfit/loadout/offl, //Sentinel
+	)
+
+	outfit = /datum/outfit/job/bos/f13offdutybos
+
+	access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
+	minimal_access = list(ACCESS_ROBOTICS, ACCESS_BOS, ACCESS_ENGINE_EQUIP, ACCESS_ENGINE, ACCESS_HYDROPONICS, ACCESS_KITCHEN, ACCESS_BAR, ACCESS_SEC_DOORS)
+
+/datum/outfit/job/bos/f13offdutybos
+	name = "Off-Duty"
+	jobtype = /datum/job/bos/f13offdutybos
+	backpack = /obj/item/storage/backpack
+	ears = 			/obj/item/radio/headset
+	uniform =		/obj/item/clothing/under/syndicate
+	belt = 			/obj/item/storage/belt/military/army
+	shoes = 		/obj/item/clothing/shoes/combat
+	gloves = 		/obj/item/clothing/gloves/combat
+	id = 			/obj/item/card/id/dogtag
+	backpack_contents = list(
+		/obj/item/reagent_containers/hypospray/medipen/stimpak=2,
+		/obj/item/encryptionkey/headset_bos=1,
+		)
+
+/datum/outfit/loadout/offa
+	name = "Junior Knight"
+	head = /obj/item/clothing/head/helmet/f13/combat
+	suit = /obj/item/clothing/suit/armor/f13/combat
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/juniorknight=1
+		)
+
+/datum/outfit/loadout/offb
+	name = "Knight"
+	head = /obj/item/clothing/head/helmet/f13/combat
+	suit = /obj/item/clothing/suit/armor/f13/combat
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
+		/obj/item/clothing/accessory/bos/knight=1
+		)
+
+/datum/outfit/loadout/offc
+	name = "Senior Knight"
+	head = /obj/item/clothing/head/helmet/f13/combat
+	suit = /obj/item/clothing/suit/armor/f13/combat
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/pistol/n99=1,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
+		/obj/item/clothing/accessory/bos/seniorknight=1
+		)
+
+/datum/outfit/loadout/offd
+	name = "Knight-Captain"
+	head = /obj/item/clothing/head/helmet/f13/combat/mk2
+	suit = /obj/item/clothing/suit/armor/f13/combat/mk2
+	backpack_contents = list(
+		/obj/item/gun/ballistic/automatic/pistol/deagle/camo=1,
+		/obj/item/ammo_box/magazine/a50=2,
+		/obj/item/clothing/accessory/bos/knightcaptain=1
+		)
+
+/datum/outfit/loadout/offe
+	name = "Junior Scribe"
+	suit = /obj/item/clothing/suit/armor/f13/battlecoat
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/wattz/magneto=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/juniorscribe=1
+		)
+
+/datum/outfit/loadout/offf
+	name = "Scribe"
+	suit = /obj/item/clothing/suit/armor/f13/battlecoat
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/wattz/magneto=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/scribe=1
+		)
+
+/datum/outfit/loadout/offg
+	name = "Senior Scribe"
+	suit = /obj/item/clothing/suit/armor/f13/battlecoat
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/wattz/magneto=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/seniorscribe=1
+		)
+
+/datum/outfit/loadout/offh
+	name = "Head Scribe"
+	suit = /obj/item/clothing/suit/armor/f13/battlecoat
+	backpack_contents = list(
+		/obj/item/gun/energy/ionrifle/carbine=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/headscribe=1
+		)
+
+/datum/outfit/loadout/offi
+	name = "Junior Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
+	head = /obj/item/clothing/head/helmet/knight/fluff/metal
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/juniorpaladin=1
+		)
+
+/datum/outfit/loadout/offj
+	name = "Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
+	head = /obj/item/clothing/head/helmet/knight/fluff/metal
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/paladin=1
+		)
+
+/datum/outfit/loadout/offk
+	name = "Senior Paladin"
+	suit = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/coat
+	head = /obj/item/clothing/head/helmet/knight/fluff/metal
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/pistol=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/seniorpaladin=1
+		)
+
+/datum/outfit/loadout/offl
+	name = "Sentinel"
+	suit = /obj/item/clothing/suit/armor/f13/leather_jacket/combat/riotpolice
+	head = /obj/item/clothing/head/helmet/knight/fluff/metal/reinforced
+	backpack_contents = list(
+		/obj/item/gun/energy/laser/plasma/glock=1,
+		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/clothing/accessory/bos/sentinel=1
 		)

--- a/code/modules/jobs/job_types/bos.dm
+++ b/code/modules/jobs/job_types/bos.dm
@@ -823,7 +823,7 @@ Off-Duty
 	suit = /obj/item/clothing/suit/armor/f13/combat
 	backpack_contents = list(
 		/obj/item/gun/ballistic/automatic/pistol/n99=1,
-		/obj/item/stock_parts/cell/ammo/ec=2,
+		/obj/item/ammo_box/magazine/m10mm_adv=2,
 		/obj/item/clothing/accessory/bos/juniorknight=1
 		)
 

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -38,6 +38,7 @@ GLOBAL_LIST_INIT(faction_whitelist_positions, list(
 "Knight",
 "Senior Scribe",
 "Scribe",
+"Off-Duty",
 "Legion Centurion",
 "Legion Orator",
 "Priestess of Mars",
@@ -75,6 +76,7 @@ GLOBAL_LIST_INIT(faction_player_positions, list(
 "Knight",
 "Senior Scribe",
 "Scribe",
+"Off-Duty",
 "Legion Decanus",
 "Veteran Legionary",
 "Prime Legionary",
@@ -113,7 +115,7 @@ GLOBAL_LIST_INIT(brotherhood_positions, list(
 	"Knight",
 	"Senior Scribe",
 	"Scribe",
-	"Initiate"
+	"Off-Duty",
 ))
 
 GLOBAL_LIST_INIT(den_command_positions, list(
@@ -271,7 +273,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
     EXP_TYPE_WASTELAND     = list("titles" = wasteland_positions),
 	EXP_TYPE_TRIBAL        = list("titles" = tribal_positions),
 	EXP_TYPE_FOLLOWERS     = list("titles" = followers_positions),
-	
+
     EXP_TYPE_RANGER        = list("titles" = list("NCR Veteran Ranger","NCR Ranger")),
     EXP_TYPE_SCRIBE        = list("titles" = list("Scribe")),
     EXP_TYPE_DECANUS       = list("titles" = list("Legion Decanus")),

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -18,6 +18,7 @@
 	var/rigged = FALSE	// true if rigged to explode
 	var/chargerate = 100 //how much power is given every tick in a recharger
 	var/self_recharge = 0 //does it self recharge, over time, or not?
+	var/cancharge = 1 //set to 0 if you do not want this battery to be able to charge
 	var/ratingdesc = TRUE
 	var/grown_battery = FALSE // If it's a grown that acts as a battery, add a wire overlay to it.
 	container_type = INJECTABLE|DRAINABLE
@@ -33,7 +34,7 @@
 		maxcharge = override_maxcharge
 	charge = maxcharge
 	if(ratingdesc)
-		desc += " This one has a rating of [DisplayEnergy(maxcharge)], and you should not swallow it."
+		desc += " This one has a rating of [DisplayEnergy(maxcharge)]."
 	update_icon()
 
 /obj/item/stock_parts/cell/Destroy()
@@ -364,6 +365,7 @@
 /obj/item/stock_parts/cell/ammo
 	name = "ammo cell"
 	desc = "You shouldn't be holding this."
+	cancharge = 0
 	w_class = WEIGHT_CLASS_TINY
 
 /obj/item/stock_parts/cell/ammo/New()
@@ -378,21 +380,18 @@
 	desc = "A microfusion cell, typically used as ammunition for large energy weapons."
 	icon_state = "mfc"
 	maxcharge = 1200
-	chargerate = 300
 
 /obj/item/stock_parts/cell/ammo/ecp
 	name = "electron charge pack"
 	desc = "An electron charge pack, typically used as ammunition for rapidly-firing energy weapons."
 	icon_state = "icell"
 	maxcharge = 2400
-	chargerate = 400
 
 /obj/item/stock_parts/cell/ammo/ec
 	name = "energy cell"
 	desc = "An energy cell, typically used as ammunition for small-arms energy weapons."
 	icon_state = "ec"
-	maxcharge = 300
-	chargerate = 300
+	maxcharge = 600
 
 /obj/item/stock_parts/cell/ammo/alien
 	name = "alien weapon cell"
@@ -400,4 +399,3 @@
 	icon_state = "aliencell"
 	ratingdesc = FALSE
 	maxcharge = 4000
-	chargerate = 0

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -72,12 +72,12 @@
 	pellets = 3
 	variance = 14
 	select_name = "scatter"
-	e_cost = 75
+	e_cost = 100
 	fire_sound = 'sound/f13weapons/tribeamfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pistol
 	projectile_type = /obj/item/projectile/beam/laser/pistol
-	e_cost = 10
+	e_cost = 50
 	fire_sound = 'sound/f13weapons/aep7fire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz
@@ -89,7 +89,7 @@
 
 /obj/item/ammo_casing/energy/laser/lasgun
 	projectile_type = /obj/item/projectile/beam/laser/lasgun
-	e_cost = 50
+	e_cost = 75
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
 
 //musket
@@ -107,15 +107,15 @@
 
 /obj/item/ammo_casing/energy/laser/rcw
 	projectile_type = /obj/item/projectile/beam/laser/rcw
-	e_cost = 75
+	e_cost = 150
 	fire_sound = 'sound/f13weapons/rcwfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/laer
 	projectile_type = /obj/item/projectile/beam/laser/laer
-	e_cost = 100
+	e_cost = 150
 	fire_sound = 'sound/f13weapons/laerfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/aer14
 	projectile_type = /obj/item/projectile/beam/laser/aer14
-	e_cost = 50
+	e_cost = 100
 	fire_sound = 'sound/f13weapons/aer14fire.ogg'

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -20,26 +20,26 @@
 	icon_state = "neurotoxin"
 	fire_sound = 'sound/f13weapons/plasma_rifle.ogg'
 	delay = 5
-	e_cost = 75
+	e_cost = 150
 
 /obj/item/ammo_casing/energy/plasma/scatter
 	projectile_type = /obj/item/projectile/plasma/scatter
 	pellets = 3
 	variance = 14
 	select_name = "scatter"
-	e_cost = 150
+	e_cost = 200
 
 /obj/item/ammo_casing/energy/plasma/pistol
 	projectile_type = /obj/item/projectile/plasma/pistol
 	fire_sound = 'sound/f13weapons/plasma_pistol.ogg'
-	e_cost = 75
+	e_cost = 100
 
 /obj/item/ammo_casing/energy/plasma/pistol/glock
 	projectile_type = /obj/item/projectile/plasma/pistol/glock
-	e_cost = 18.75
+	e_cost = 50
 
 /obj/item/ammo_casing/energy/plasma/pistol/glock/extended
-	e_cost = 9.375
+	e_cost = 25
 
 /obj/item/ammo_casing/energy/plasma/alien
 	projectile_type = /obj/item/projectile/plasma/alien

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -321,7 +321,7 @@
 	item_state = "rcw"
 	fire_delay = 3
 	burst_size = 2
-	burst_delay = 2
+	burst_delay = 2.5
 	equipsound = 'sound/f13weapons/equipsounds/RCWequip.ogg'
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/rcw)
 	cell_type = /obj/item/stock_parts/cell/ammo/ecp

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -215,17 +215,17 @@
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"
-	damage = 26
+	damage = 30
 	armour_penetration = 15
 
 /obj/item/projectile/beam/laser/pistol //AEP7
 	name = "laser beam"
-	damage = 21
+	damage = 23
 	armour_penetration = 10
 
 /obj/item/projectile/beam/laser/gatling //Gatling Laser Projectile
 	name = "rapid-fire laser beam"
-	damage = 12
+	damage = 10
 	armour_penetration = 50
 
 /obj/item/projectile/beam/laser/pistol/wattz //Wattz pistol
@@ -243,8 +243,8 @@
 
 /obj/item/projectile/beam/laser/tribeam //Tribeam laser, fires 3 shots, will melt you
 	name = "tribeam laser"
-	damage = 22
-	armour_penetration = 12
+	damage = 21
+	armour_penetration = 10
 
 /obj/item/projectile/plasma //Plasma rifle
 	name = "plasma bolt"
@@ -267,10 +267,10 @@
 	is_reflectable = FALSE
 
 /obj/item/projectile/plasma/pistol //Plasma pistol
-	damage = 28
+	damage = 35
 	armour_penetration = 20
 
-/obj/item/projectile/plasma/pistol/glock //Glock (upgraded plasma pistol)
+/obj/item/projectile/plasma/pistol/glock //Glock (streamlined plasma pistol)
 	damage = 28
 	armour_penetration = 15
 
@@ -281,7 +281,7 @@
 /obj/item/projectile/beam/laser/rcw //RCW
 	name = "rapidfire beam"
 	icon_state = "xray"
-	damage = 15
+	damage = 22
 	armour_penetration = 12
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
@@ -289,20 +289,20 @@
 /obj/item/projectile/plasma/alien
 	name = "alien projectile"
 	icon_state = "ion"
-	damage = 85 //horrifyingly powerful, but very limited ammo
+	damage = 90 //horrifyingly powerful, but very limited ammo
 	armour_penetration = 50
 
 /obj/item/projectile/beam/laser/laer //Elder's/Unique LAER
 	name = "advanced laser beam"
 	icon_state = "u_laser"
-	damage = 40
-	armour_penetration = 30
+	damage = 45
+	armour_penetration = 50
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
-	damage = 30
+	damage = 35
 	armour_penetration = 20
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser


### PR DESCRIPTION


<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Adds the Off-Duty BOS role, who are either operatives or are, simply, off duty members of the Brotherhood. They are typically required to be in pairs or more, but solo ops are allowed at times. Brotherhood characters /must/ play this role and no longer can be regular wastelanders.

Buffed energy weapon damage, with armor values to reflect this damage change soon; however, energy weapons can no longer be recharged.

You can craft all 3 energy weapon ammo types using the crafting menu now.

## Motivation and Context
As taken from #suggestions in the Discord, it was requested that energy weapon damage was made higher; at the contrast of no longer being able to charge them. This has been made realized along with a role for off-duty Brotherhood members.

## How Has This Been Tested?
Tested fully on my private server, everything seems to be working.

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
add: Craftable energy ammo cells
add: BOS off duty role
del: Removed ability to charge energy ammo cells
tweak: Damage output for energy weapons
/:cl:
