### PR TITLE
Energy Weapon Rebalance 2.0

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -218,12 +218,23 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
+/datum/crafting_recipe/cell
+	name = "Power Cell"
+	result = /obj/item/stock_parts/cell
+	reqs = list(/obj/item/stack/crafting/electronicparts = 1,
+				/obj/item/stack/sheet/glass = 5,
+				/obj/item/stack/sheet/metal = 5)
+	tools = list(TOOL_WORKBENCH)
+	time = 10
+	category = CAT_WEAPONRY
+	subcategory = CAT_AMMO
+
 /datum/crafting_recipe/ec
 	name = "Small Energy Cell"
 	result = /obj/item/stock_parts/cell/ammo/ec
-	reqs = list(/obj/item/stack/sheet/metal = 1, /obj/item/stock_parts/cell=2)
-	traits = list(TRAIT_GUNSMITH_TWO)
-	tools = list(TOOL_WORKBENCH, TOOL_GUNTIER2)
+	reqs = list(/obj/item/stock_parts/cell=2)
+	traits = list(TRAIT_GUNSMITH_ONE)
+	tools = list(TOOL_WORKBENCH, TOOL_GUNTIER1)
 	time = 10
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
@@ -231,9 +242,9 @@
 /datum/crafting_recipe/mfc
 	name = "Microfusion Cell"
 	result = /obj/item/stock_parts/cell/ammo/mfc
-	reqs = list(/obj/item/stock_parts/capacitor=1, /obj/item/stock_parts/cell/ammo/ec=2)
-	traits = list(TRAIT_GUNSMITH_THREE)
-	tools = list(TOOL_AWORKBENCH, TOOL_GUNTIER3)
+	reqs = list(/obj/item/stack/crafting/goodparts=1, /obj/item/stock_parts/cell/ammo/ec=2)
+	traits = list(TRAIT_GUNSMITH_TWO)
+	tools = list(TOOL_AWORKBENCH, TOOL_GUNTIER2)
 	time = 20
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
@@ -242,9 +253,9 @@
 /datum/crafting_recipe/ecp
 	name = "Electron Charge Pack"
 	result = /obj/item/stock_parts/cell/ammo/ecp
-	reqs = list(/obj/item/stock_parts/capacitor=2, /obj/item/stock_parts/cell/ammo/mfc=2)
-	traits = list(TRAIT_GUNSMITH_FOUR)
-	tools = list(TOOL_AWORKBENCH, TOOL_GUNTIER4)
+	reqs = list(/obj/item/stock_parts/capacitor=1, /obj/item/stock_parts/cell/ammo/mfc=2)
+	traits = list(TRAIT_GUNSMITH_THREE)
+	tools = list(TOOL_AWORKBENCH, TOOL_GUNTIER3)
 	time = 30
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO

--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -379,7 +379,7 @@
 	name = "microfusion cell"
 	desc = "A microfusion cell, typically used as ammunition for large energy weapons."
 	icon_state = "mfc"
-	maxcharge = 1200
+	maxcharge = 2000
 
 /obj/item/stock_parts/cell/ammo/ecp
 	name = "electron charge pack"
@@ -391,7 +391,7 @@
 	name = "energy cell"
 	desc = "An energy cell, typically used as ammunition for small-arms energy weapons."
 	icon_state = "ec"
-	maxcharge = 600
+	maxcharge = 1600
 
 /obj/item/stock_parts/cell/ammo/alien
 	name = "alien weapon cell"

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -72,33 +72,25 @@
 	pellets = 3
 	variance = 14
 	select_name = "scatter"
-	e_cost = 100
+	e_cost = 180 //11 shots
 	fire_sound = 'sound/f13weapons/tribeamfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pistol
 	projectile_type = /obj/item/projectile/beam/laser/pistol
-	e_cost = 50
+	e_cost = 80 //20 shots
 	fire_sound = 'sound/f13weapons/aep7fire.ogg'
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz
-	e_cost = 25
+	e_cost = 100 //16 shots
 
 /obj/item/ammo_casing/energy/laser/pistol/wattz/magneto
 	projectile_type = /obj/item/projectile/beam/laser/pistol/wattz/magneto
 
 /obj/item/ammo_casing/energy/laser/lasgun
 	projectile_type = /obj/item/projectile/beam/laser/lasgun
-	e_cost = 75
+	e_cost = 100 //20 shots
 	fire_sound = 'sound/f13weapons/aer9fire.ogg'
-
-//musket
-
-/obj/item/ammo_casing/energy/laser/musket
-	projectile_type = /obj/item/projectile/beam/laser/musket
-	e_cost = 250
-	fire_sound = 'sound/f13weapons/aer9fire.ogg'
-//
 
 /obj/item/ammo_casing/energy/laser/solar
 	projectile_type = /obj/item/projectile/beam/laser/solar
@@ -107,15 +99,22 @@
 
 /obj/item/ammo_casing/energy/laser/rcw
 	projectile_type = /obj/item/projectile/beam/laser/rcw
-	e_cost = 150
+	e_cost = 100 //24 shots
 	fire_sound = 'sound/f13weapons/rcwfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/laer
 	projectile_type = /obj/item/projectile/beam/laser/laer
-	e_cost = 150
+	e_cost = 125 //16 shots
 	fire_sound = 'sound/f13weapons/laerfire.ogg'
 
 /obj/item/ammo_casing/energy/laser/aer14
 	projectile_type = /obj/item/projectile/beam/laser/aer14
-	e_cost = 100
+	e_cost = 80 //25 shots
 	fire_sound = 'sound/f13weapons/aer14fire.ogg'
+
+//musket
+
+/obj/item/ammo_casing/energy/laser/musket
+	projectile_type = /obj/item/projectile/beam/laser/musket
+	e_cost = 250
+	fire_sound = 'sound/f13weapons/aer9fire.ogg'

--- a/code/modules/projectiles/ammunition/energy/plasma.dm
+++ b/code/modules/projectiles/ammunition/energy/plasma.dm
@@ -1,14 +1,14 @@
 /obj/item/ammo_casing/energy/plasma/adv
 	projectile_type = /obj/item/projectile/plasma/weak/adv
 	delay = 10
-	e_cost = 10
+	e_cost = 50 //not sure where this is used, but 32 in an EC and 40 in an MFC.
 
 /obj/item/ammo_casing/energy/plasma/weak
 	projectile_type = /obj/item/projectile/plasma/weak
 	select_name = "plasma burst"
 	fire_sound = 'sound/weapons/plasma_cutter.ogg'
 	delay = 15
-	e_cost = 25
+	e_cost = 100 //20 shots
 
 /*
 ---Fallout 13---
@@ -20,26 +20,26 @@
 	icon_state = "neurotoxin"
 	fire_sound = 'sound/f13weapons/plasma_rifle.ogg'
 	delay = 5
-	e_cost = 150
+	e_cost = 160 //12 shots
 
 /obj/item/ammo_casing/energy/plasma/scatter
 	projectile_type = /obj/item/projectile/plasma/scatter
 	pellets = 3
 	variance = 14
 	select_name = "scatter"
-	e_cost = 200
+	e_cost = 200 //10 shots
 
 /obj/item/ammo_casing/energy/plasma/pistol
 	projectile_type = /obj/item/projectile/plasma/pistol
 	fire_sound = 'sound/f13weapons/plasma_pistol.ogg'
-	e_cost = 100
+	e_cost = 200 //8 shots
 
 /obj/item/ammo_casing/energy/plasma/pistol/glock
 	projectile_type = /obj/item/projectile/plasma/pistol/glock
-	e_cost = 50
+	e_cost = 160 //10 shots
 
 /obj/item/ammo_casing/energy/plasma/pistol/glock/extended
-	e_cost = 25
+	e_cost = 80 //20 shots
 
 /obj/item/ammo_casing/energy/plasma/alien
 	projectile_type = /obj/item/projectile/plasma/alien

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -227,13 +227,14 @@
 	name ="plasma rifle"
 	item_state = "plasma"
 	icon_state = "plasma"
-	fire_delay = 3
+	fire_delay = 3.5
 	desc = "A top of line miniaturized plasma caster built by REPCONN in the wake of the Z43-521P failure. It is supperior to all previous rifles to enter service in the USCC."
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	equipsound = 'sound/f13weapons/equipsounds/plasequip.ogg'
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	projectile_speed = 1.1
 
 /obj/item/gun/energy/laser/plasma/scatter
 	name = "multiplas Rifle"
@@ -245,6 +246,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/plasma/scatter)
 	cell_type = /obj/item/stock_parts/cell/ammo/mfc
 	weapon_weight = WEAPON_HEAVY
+	projectile_speed = 1.2
 
 /obj/item/gun/energy/laser/plasma/pistol
 	name ="plasma pistol"
@@ -257,6 +259,7 @@
 	equipsound = 'sound/f13weapons/equipsounds/pistolplasequip.ogg'
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
 	slot_flags = ITEM_SLOT_BELT
+	projectile_speed = 1.1
 
 /obj/item/gun/energy/laser/plasma/glock
 	name = "glock 86"
@@ -269,6 +272,7 @@
 	equipsound = 'sound/f13weapons/equipsounds/pistolplasequip.ogg'
 	cell_type = /obj/item/stock_parts/cell/ammo/ec
 	slot_flags = ITEM_SLOT_BELT
+	projectile_speed = 1.1
 
 /obj/item/gun/energy/laser/plasma/glock/extended
 	name ="glock 86a"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -203,42 +203,42 @@
 	armour_penetration = 25
 
 //plasma caster
-/obj/item/projectile/plasmacaster //Plasma rifle
+/obj/item/projectile/plasmacaster
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
 	damage = 50
 	armour_penetration = 30
-	flag = "laser" //checks vs. energy protection
+	flag = "laser"
 	eyeblur = 0
 	is_reflectable = TRUE
 
 /obj/item/projectile/beam/laser/lasgun //AER9
 	name = "laser beam"
-	damage = 30
-	armour_penetration = 15
+	damage = 33
+	armour_penetration = 20
 
 /obj/item/projectile/beam/laser/pistol //AEP7
 	name = "laser beam"
-	damage = 23
-	armour_penetration = 10
+	damage = 28
+	armour_penetration = 15
 
 /obj/item/projectile/beam/laser/gatling //Gatling Laser Projectile
 	name = "rapid-fire laser beam"
-	damage = 10
-	armour_penetration = 50
+	damage = 12
+	armour_penetration = 40
 
 /obj/item/projectile/beam/laser/pistol/wattz //Wattz pistol
-	damage = 18
+	damage = 24
 
 /obj/item/projectile/beam/laser/pistol/wattz/magneto //upgraded Wattz
 	name = "penetrating laser beam"
-	damage = 20
-	armour_penetration = 10
+	damage = 25
+	armour_penetration = 15
 
 /obj/item/projectile/beam/laser/solar //Solar Scorcher
 	name = "solar scorcher beam"
-	damage = 20
+	damage = 28
 	armour_penetration = 20
 
 /obj/item/projectile/beam/laser/tribeam //Tribeam laser, fires 3 shots, will melt you
@@ -250,8 +250,8 @@
 	name = "plasma bolt"
 	icon_state = "plasma_clot"
 	damage_type = BURN
-	damage = 35
-	armour_penetration = 25
+	damage = 42
+	armour_penetration = 12
 	flag = "laser" //checks vs. energy protection
 	eyeblur = 0
 	is_reflectable = TRUE
@@ -267,22 +267,22 @@
 	is_reflectable = FALSE
 
 /obj/item/projectile/plasma/pistol //Plasma pistol
-	damage = 35
-	armour_penetration = 20
+	damage = 45
+	armour_penetration = 3
 
 /obj/item/projectile/plasma/pistol/glock //Glock (streamlined plasma pistol)
-	damage = 28
+	damage = 30
 	armour_penetration = 15
 
 /obj/item/projectile/plasma/scatter //Multiplas, fires 3 shots, will melt you
-	damage = 26
-	armour_penetration = 30
+	damage = 31
+	armour_penetration = 10
 
 /obj/item/projectile/beam/laser/rcw //RCW
 	name = "rapidfire beam"
 	icon_state = "xray"
-	damage = 22
-	armour_penetration = 12
+	damage = 24
+	armour_penetration = 15
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/green_laser
 	light_color = LIGHT_COLOR_GREEN
 
@@ -302,8 +302,8 @@
 
 /obj/item/projectile/beam/laser/aer14 //AER14
 	name = "laser beam"
-	damage = 35
-	armour_penetration = 20
+	damage = 33
+	armour_penetration = 34
 	icon_state = "omnilaser"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -34,5 +34,5 @@
 
 //2mm Electromagnetic
 /obj/item/projectile/bullet/c2mm
-	damage = 45
-	armour_penetration = 45
+	damage = 55
+	armour_penetration = 50


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
This change should adapt energy weapons to be feasible in both PVP and PVE once more. Given that they have been stripped of their charge rates, they have been given a slight damage increase to be on par with their ballistic counterparts.

Additionally, the crafting recipes for energy cells has been changed; they should be easier to make in the wasteland now, and I've added a 'battery' crafting ability, so you don't need access to an autolathe anymore.

Plasma weapons have been given a hefty damage increase but no longer do very much penetration and have slower projectile speeds.

The Gauss rifle has been made less-suck.

Let's see how this does.

## Motivation and Context
So, I screwed up a little in nerfing these weapons in the first place. This should account for that change and has been put to a vote on how people wished to see this change accounted for.


## How Has This Been Tested?
This has been very, very thoroughly tested by myself. I'm quite pleased with the results as I've tested nearly every weapon changed on all armor in the game. Energy weapons from the AER9 series are on par with their ballistic counterparts, above that slightly better, and below that slightly worse.

## Changelog (necessary)
:cl:

balance: energy weapon damage
balance: energy weapon capacity
balance: plasma weapon damage/capacity/projectile speed
add: battery crafting option


/:cl:
