### PR TITLE
removes that weird clone thing, adds logging to AM

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -687,6 +687,7 @@
 	throw_speed = 4
 	attack_verb = list("gored")
 
+/* Im not removing it, but commenting it out. Its a good example of stuff, but it isnt really good for the server, no?
 /obj/item/twohanded/spear/grey_tide/afterattack(atom/movable/AM, mob/living/user, proximity)
 	. = ..()
 	if(!proximity)
@@ -701,6 +702,7 @@
 			M.faction = user.faction.Copy()
 			M.Copy_Parent(user, 100, user.health/2.5, 12, 30)
 			M.GiveTarget(L)
+*/
 
 /obj/item/twohanded/pitchfork
 	icon_state = "pitchfork0"

--- a/code/modules/power/antimatter/control.dm
+++ b/code/modules/power/antimatter/control.dm
@@ -353,11 +353,15 @@
 
 	if(href_list["strengthup"])
 		fuel_injection++
+		log_game("[key_name(usr)] has changed the fuel injection to [fuel_injection] for the AM.")
+		message_admins("[key_name(usr)] has changed the fuel injection to [fuel_injection] for the AM.")
 
 	if(href_list["strengthdown"])
 		fuel_injection--
 		if(fuel_injection < 0)
 			fuel_injection = 0
+		log_game("[key_name(usr)] has changed the fuel injection to [fuel_injection] for the AM.")
+		message_admins("[key_name(usr)] has changed the fuel injection to [fuel_injection] for the AM.")
 
 	if(href_list["refreshstability"])
 		check_core_stability()


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
removes a weird cloning thing from a glaive
adds logging to AM engine
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
that weird cloning thing doesnt seem very lore friendly... at all.
logging so sabo'ing the AM can be known to staff
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
compiled and tested
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
del: removed cloning from greytide glaive
/:cl:
