### PR TITLE
minor weapon tweaks

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -567,6 +567,7 @@
 	var/force_on = 60
 	w_class = WEIGHT_CLASS_BULKY
 	throwforce = 20
+	reach = 2
 	throw_speed = 2
 	throw_range = 4
 	materials = list(MAT_METAL=13000)

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -3,8 +3,8 @@
 /obj/item/projectile/bullet/p50
 	name =".50 bullet"
 	speed = 0.4
-	damage = 55
-	knockdown = 100
+	damage = 60
+	knockdown = 0
 	dismemberment = 30
 	armour_penetration = 25
 	var/breakthings = TRUE


### PR DESCRIPTION
## Description
Nerfed AMR mk2, buffed thermic lance.

## Motivation and Context
AMR mk2 was busted with the knockdown, hitscan, high damage and delimb. Knockdown completely removed from the ammo, damage tweaked to bring in line with the regular AMR.
Thermic lance given the same range as glaive and spear, one extra tile away. More viable against mobs and people now.

## How Has This Been Tested?
Compiled and ran both, confirmed to be no knockdown on the AMR and extra range on the lance.

## Changelog (necessary)
50 BMG lost knockdown
50 BMG +5 damage to bring in line with 50MG
Thermic Lance given extra range.
