### PR TITLE
Revert "Typing indicators fix"

### DIFF
--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -81,10 +81,10 @@
 			return
 	return ..()
 
-/*/mob/key_down(_key, client/user)
+/mob/key_down(_key, client/user)
 	switch(_key)
 		if("T")
 			src.set_typing_indicator(TRUE)
 		if("M")
 			src.set_typing_indicator(TRUE)
-	return ..()*/
+	return ..()

--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -1,7 +1,7 @@
 //Speech verbs.
 /mob/verb/say_typing_indicator()
-	set name = "Say"
-	set hidden = FALSE
+	set name = "say_indicator"
+	set hidden = TRUE
 	set category = "IC"
 	display_typing_indicator()
 	var/message = input(usr, "", "say") as text|null
@@ -12,11 +12,11 @@
 	return say_verb(message)
 
 /mob/verb/me_typing_indicator()
-	set name = "Me"
-	set hidden = FALSE
+	set name = "me_indicator"
+	set hidden = TRUE
 	set category = "IC"
 	display_typing_indicator()
-	var/message = input(usr, "", "me") as text|null
+	var/message = input(usr, "", "me") as message|null
 	// If they don't type anything just drop the message.
 	clear_typing_indicator()		// clear it immediately!
 	if(!length(message))
@@ -24,9 +24,8 @@
 	return me_verb(message)
 
 /mob/verb/say_verb(message as text)
-	set name = "say_noindicator"
+	set name = "say"
 	set category = "IC"
-	set hidden = TRUE
 	if(!length(message))
 		return
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
@@ -51,9 +50,7 @@
 	say(message, language) //only living mobs actually whisper, everything else just talks
 
 /mob/verb/me_verb(message as text) //Moving from message to text because single-line input boxes are more user-friendly
-	set name = "Me_noindicator"
-	set hidden = TRUE
-
+	set name = "Me"
 	set category = "IC"
 	if(GLOB.say_disabled)	//This is here to try to identify lag problem
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -56,11 +56,7 @@ GLOBAL_LIST_EMPTY(typing_indicator_overlays)
 
 /mob/proc/set_typing_indicator(var/state)
 	if(!typing_indicator)
-<<<<<<< HEAD
-		typing_indicator = mutable_appearance('icons/mob/talk.dmi', "normal_typing", FLY_LAYER)
-=======
 		typing_indicator = mutable_appearance('icons/mob/talk.dmi', "default0", FLY_LAYER)
->>>>>>> pr/25
 	if(client && !stat)
 		if(state)
 			if(!typing)


### PR DESCRIPTION
Reverts judgex/desertrose#616

There was a syntax error, tried to fix it but it didn't work out right - players had to use macro mode to speak at all.