### PR TITLE
tactical laser reload

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -267,8 +267,8 @@
 			else
 				to_chat(user, "<span class='warning'>You cannot seem to get \the [src] out of your hands!</span>")
 				return
-		else if (cell)
-			to_chat(user, "<span class='notice'>There's already a cell in \the [src].</span>")
+		//else if (cell)
+			//to_chat(user, "<span class='notice'>There's already a cell in \the [src].</span>")
 
 /obj/item/gun/energy/examine(mob/user)
 	..()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -253,6 +253,24 @@
 	else 
 		return
 
+/obj/item/gun/energy/attack_self(mob/living/user)
+	if (!ishuman(user))
+		return
+	if(cell)
+		if(can_charge == 0)
+			to_chat(user, "<span class='notice'>You can't remove the cell from \the [src].</span>")
+			return
+		cell.forceMove(drop_location())
+		user.put_in_hands(cell)
+		cell.update_icon()
+		cell = null
+		to_chat(user, "<span class='notice'>You pull the cell out of \the [src].</span>")
+		playsound(src, 'sound/f13weapons/equipsounds/laserreload.ogg', 50, 1)
+	else
+		to_chat(user, "<span class='notice'>There's no cell in \the [src].</span>")
+	return
+
+
 /obj/item/gun/energy/attackby(obj/item/A, mob/user, params)
 	..()
 	if (istype(A, /obj/item/stock_parts/cell/ammo))

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -190,8 +190,8 @@
 					oldcell.dropped()
 					oldcell.forceMove(get_turf(src.loc))
 					oldcell.update_icon()
-				else
-					to_chat(user, "<span class='notice'>You insert the cell into \the [src].</span>")
+				//else
+				//	to_chat(user, "<span class='notice'>You insert the cell into \the [src].</span>")
 
 				//playsound(src, 'sound/weapons/autoguninsert.ogg', 60, TRUE)
 				//chamber_round()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -175,6 +175,32 @@
 //	w_class = WEIGHT_CLASS_BULKY
 //	weapon_weight = WEAPON_HEAVY
 
+/obj/item/gun/energy/laser/attackby(obj/item/A, mob/user, params)
+	. = ..()
+	if(.)
+		return
+	if(istype(A, /obj/item/stock_parts/cell/ammo))
+		var/obj/item/stock_parts/cell/ammo/AM = A
+		if(istype(AM, cell_type))
+			var/obj/item/stock_parts/cell/ammo/oldcell = cell
+			if(user.transferItemToLoc(AM, src))
+				cell = AM
+				if(oldcell)
+					to_chat(user, "<span class='notice'>You perform a tactical reload on \the [src], replacing the cell.</span>")
+					oldcell.dropped()
+					oldcell.forceMove(get_turf(src.loc))
+					oldcell.update_icon()
+				else
+					to_chat(user, "<span class='notice'>You insert the cell into \the [src].</span>")
+
+				//playsound(src, 'sound/weapons/autoguninsert.ogg', 60, TRUE)
+				//chamber_round()
+				A.update_icon()
+				update_icon()
+				return 1
+			else
+				to_chat(user, "<span class='warning'>You cannot seem to get \the [src] out of your hands!</span>")
+
 /obj/item/gun/energy/laser/aer9
 	name = "\improper AER9 laser rifle"
 	desc = "A sturdy and advanced military grade pre-war service laser rifle"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Allows laser weapons to be reloaded by using a new cell on them like automatic weapons.

Also added unloading laser weapons by left clicking like regular ballistics.
## Motivation and Context
I don't see why this isn't already a thing.

## How Has This Been Tested?
Works locally.
