### PR TITLE
Can no longer remove battery from kinetic accelerator

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -46,9 +46,9 @@
 /obj/item/gun/energy/kinetic_accelerator/AltClick(mob/user)
 	return
 
-/obj/item/gun/energy/attack_self(mob/living/user)
+/obj/item/gun/energy/kinetic_accelerator/attack_self(mob/living/user)
 	return
-	
+
 /obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/borg/upgrade/modkit))
 		var/obj/item/borg/upgrade/modkit/MK = I

--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -43,6 +43,12 @@
 	else
 		to_chat(user, "<span class='notice'>There are no modifications currently installed.</span>")
 
+/obj/item/gun/energy/kinetic_accelerator/AltClick(mob/user)
+	return
+
+/obj/item/gun/energy/attack_self(mob/living/user)
+	return
+	
 /obj/item/gun/energy/kinetic_accelerator/attackby(obj/item/I, mob/user)
 	if(istype(I, /obj/item/borg/upgrade/modkit))
 		var/obj/item/borg/upgrade/modkit/MK = I


### PR DESCRIPTION
Not needed because of auto-recharge and harmful because the battery cannot be re-inserted once removed.