### PR TITLE
Bullet penetration version 0.1

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -99,6 +99,8 @@
 	var/dismemberment = 0 //The higher the number, the greater the bonus to dismembering. 0 will not dismember at all.
 	var/impact_effect_type //what type of impact effect to show when hitting something
 	var/log_override = FALSE //is this type spammed enough to not log? (KAs)
+	var/penetrating = 0
+	var/bumped = 0
 
 /obj/item/projectile/Initialize()
 	. = ..()
@@ -208,6 +210,11 @@
 	beam_index = pcache
 	beam_segments[beam_index] = null
 
+/obj/item/projectile/proc/check_penetrate(var/atom/A)
+	return 1
+
+/var/passthrough = 0
+
 /obj/item/projectile/Bump(atom/A)
 	var/datum/point/pcache = trajectory.copy_to()
 	if(check_ricochet(A) && check_ricochet_flag(A) && ricochets < ricochets_max)
@@ -259,6 +266,18 @@
 					passthrough = 1
 					return
 			if (istype(A, /obj/structure/barricade/sandbags))
+				if (prob(penetrating-25))
+					passthrough = 1
+					return
+			if (istype(A, /turf/closed/wall/mineral/sandstone))
+				if (prob(penetrating-25))
+					passthrough = 1
+					return
+			if (istype(A, /turf/closed/wall))
+				if (prob(penetrating-25))
+					passthrough = 1
+					return
+			if (istype(A, /turf/closed/wall/rust))
 				if (prob(penetrating-25))
 					passthrough = 1
 					return

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -244,6 +244,37 @@
 			trajectory_ignore_forcemove = FALSE
 		return FALSE
 
+	if(!passthrough && penetrating > 0)
+		if(check_penetrate(A))//TODO me wall types
+			if (istype(A, /turf/closed/wall/f13/tentwall))
+				if (prob(penetrating-0))
+					passthrough = 1
+					return
+			if (istype(A, /turf/closed/wall/f13/wood))
+				if (prob(penetrating-25))
+					passthrough = 1
+					return
+			if (istype(A, /turf/closed/wall/f13/wood/house))
+				if (prob(penetrating-25))
+					passthrough = 1
+					return
+			if (istype(A, /obj/structure/barricade/sandbags))
+				if (prob(penetrating-25))
+					passthrough = 1
+					return
+		penetrating = 0
+
+	//the bullet passes through a dense object!
+	if(passthrough)
+		//move ourselves onto A so we can continue on our way.
+		var/turf/T = get_turf(A)
+		if(T)
+			//visible_message("goes thru wall2")
+			forceMove(T)
+		permutated.Add(A)
+		bumped = 0 //reset bumped variable!
+		return 0
+
 	var/permutation = A.bullet_act(src, def_zone) // searches for return value, could be deleted after run so check A isn't null
 	if(permutation == -1 || forcedodge)// the bullet passes through a dense object!
 		trajectory_ignore_forcemove = TRUE

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -29,6 +29,7 @@
 /obj/item/projectile/bullet/c10mm
 	damage = 36 //35
 	armour_penetration = -5 //0
+	penetrating = 29
 
 /obj/item/projectile/bullet/c10mm/ap
 	damage = 25 //30

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -2,6 +2,7 @@
 /obj/item/projectile/bullet/c4570
 	damage = 50
 	armour_penetration = 15//10
+	penetrating = 60
 
 /obj/item/projectile/bullet/c4570/jhp
 	damage = 55
@@ -15,6 +16,7 @@
 /obj/item/projectile/bullet/a357
 	damage = 35 //30
 	armour_penetration = 0 //5
+	penetrating = 28
 
 /obj/item/projectile/bullet/a357/jhp
 	damage = 40 //35
@@ -31,6 +33,7 @@
 /obj/item/projectile/bullet/m44
 	damage = 41 //35
 	armour_penetration = -5 //5
+	penetrating = 55
 
 /obj/item/projectile/bullet/m44/jhp
 	damage = 60 //40
@@ -44,3 +47,4 @@
 /obj/item/projectile/bullet/a50AE
 	damage = 55
 	armour_penetration = 20
+	penetrating = 58

--- a/code/modules/projectiles/projectile/bullets/rifle.dm
+++ b/code/modules/projectiles/projectile/bullets/rifle.dm
@@ -2,6 +2,7 @@
 /obj/item/projectile/bullet/a762
 	damage = 40
 	armour_penetration = 20
+	penetrating = 65
 
 /obj/item/projectile/bullet/a762/ap
 	damage = 35
@@ -19,6 +20,7 @@
 /obj/item/projectile/bullet/a556
 	damage = 37 //35
 	armour_penetration = 0 //5
+	penetrating = 42
 
 /obj/item/projectile/bullet/a556/ap
 	damage = 25

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -7,6 +7,7 @@
 	knockdown = 100
 	dismemberment = 30
 	armour_penetration = 25
+	penetrating = 75
 	var/breakthings = TRUE
 
 /obj/item/projectile/bullet/p50/on_hit(atom/target, blocked = 0)


### PR DESCRIPTION
## Description
Currently as follows in percent.

wall/ammo | base | 10mm | 357 | 556 | 44 | 762 | 50pistol | 50rifle
-- | -- | -- | -- | -- | -- | -- | -- | --
base | 0 | 29 | 28 | 42 | 55 | 65 | 58 | 75
tent | 0 | 29 | 28 | 42 | 55 | 65 | 58 | 75
wood | -25 | 4 | 3 | 17 | 30 | 40 | 33 | 50
sandbags | -25 | 4 | 3 | 17 | 30 | 40 | 33 | 50

## Motivation and Context
Vote passed, first version doesn't include many wall types so we can see how this goes.

## How Has This Been Tested?
Tested locally, everything seems to work fine, will have to see if any issues come up.