### PR TITLE
PA Update hotfix

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -876,6 +876,9 @@
 	icon_state = "raiderpa_helm"
 	item_state = "raiderpa_helm"
 	ispowerarmor = 0
+	armor = list("melee" = 50, "bullet" = 45, "laser" = 25, "energy" = 25, "bomb" = 39, "bio" = 0, "rad" = 50, "fire" = 0, "acid" = 0)
+	strip_delay = 200
+	equip_delay_self = 20
 
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
@@ -884,6 +887,9 @@
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
 	ispowerarmor = 0
+	armor = list("melee" = 50, "bullet" = 45, "laser" = 25, "energy" = 25, "bomb" = 39, "bio" = 0, "rad" = 50, "fire" = 0, "acid" = 0)
+	strip_delay = 200
+	equip_delay_self = 20
 
 /obj/item/clothing/head/helmet/power_armor/advanced
 	name = "advanced power helmet"

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -877,8 +877,25 @@
 	item_state = "raiderpa_helm"
 	ispowerarmor = 0
 	armor = list("melee" = 50, "bullet" = 45, "laser" = 25, "energy" = 25, "bomb" = 39, "bio" = 0, "rad" = 50, "fire" = 0, "acid" = 0)
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	ispowerarmor = 1 //TRUE
 	strip_delay = 200
 	equip_delay_self = 20
+	slowdown = 0.1
+	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDEMASK|HIDEJUMPSUIT
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	clothing_flags = THICKMATERIAL
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	item_flags = SLOWS_WHILE_IN_HAND
+	flash_protect = 2
+	dynamic_hair_suffix = ""
+	dynamic_fhair_suffix = ""
+	darkness_view = 128
+	speechspan = SPAN_ROBOT //makes you sound like a robot
+	var/emped = 0
 
 
 /obj/item/clothing/head/helmet/f13/power_armor/t45b/hotrod
@@ -886,10 +903,29 @@
 	desc = "This power armor helmet is so decrepit and battle-worn that it have lost most of its capability to protect the wearer from harm."
 	icon_state = "t45hotrod_helm"
 	item_state = "t45hotrod_helm"
-	ispowerarmor = 0
+	ispowerarmor = 1
 	armor = list("melee" = 50, "bullet" = 45, "laser" = 25, "energy" = 25, "bomb" = 39, "bio" = 0, "rad" = 50, "fire" = 0, "acid" = 0)
 	strip_delay = 200
 	equip_delay_self = 20
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+	ispowerarmor = 1 //TRUE
+	strip_delay = 200
+	equip_delay_self = 20
+	slowdown = 0.1
+	flags_inv = HIDEEARS|HIDEEYES|HIDEFACE|HIDEHAIR|HIDEFACIALHAIR|HIDEMASK|HIDEJUMPSUIT
+	flags_cover = HEADCOVERSEYES | HEADCOVERSMOUTH
+	clothing_flags = THICKMATERIAL
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	item_flags = SLOWS_WHILE_IN_HAND
+	flash_protect = 2
+	dynamic_hair_suffix = ""
+	dynamic_fhair_suffix = ""
+	darkness_view = 128
+	speechspan = SPAN_ROBOT //makes you sound like a robot
+	var/emped = 0
 
 /obj/item/clothing/head/helmet/power_armor/advanced
 	name = "advanced power helmet"

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -865,9 +865,9 @@
 	desc = "It's a set of T-45b power armor with some of its plating heavily reconditioned. This set has seen better days, metal scrap has been spot welded to the chassis "
 	icon_state = "raiderpa"
 	item_state = "raiderpa"
-	armor = list("melee" = 75, "bullet" = 60, "laser" = 35, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0)
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 35, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0)
 	w_class = WEIGHT_CLASS_HUGE
-	slowdown = 0.16
+	slowdown = 0.4
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -886,10 +886,10 @@
 	desc = "It's a set of T-45b power armor with a with some of its plating removed. This set has exhaust pipes piped to the pauldrons, flames erupting from them."
 	icon_state = "t45hotrod"
 	item_state = "t45hotrod"
-	armor = list("melee" = 75, "bullet" = 60, "laser" = 35, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0)
+	armor = list("melee" = 60, "bullet" = 60, "laser" = 35, "energy" = 50, "bomb" = 48, "bio" = 60, "rad" = 50, "fire" = 80, "acid" = 0)
 	ispowerarmor = 0
 	w_class = WEIGHT_CLASS_HUGE
-	slowdown = 0.16
+	slowdown = 0.4
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	cold_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS


### PR DESCRIPTION
## Description
Removes the NVG from the PA helms, put thes armor resist where its supposed to be, stops healing through the helms, and gives it the appropriate slowdown. (Note: This will be refactored in the future, and is a stop-gap to get us the same features, albit with more lines of code.)

## Motivation and Context
Bugs

## How Has This Been Tested?
Compiled, tested locally

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Slowdown from .16 to .4 to be like other t45 sets (whoopsie)
Removes NVG from helmets
Gives helmets its robo-speech
Stops healing through PA helmet.
/:cl:
