### PR TITLE
Hotfix / Tweaks

### DIFF
--- a/_maps/templates/shelter_10.dmm
+++ b/_maps/templates/shelter_10.dmm
@@ -1,51 +1,43 @@
 "a" = (/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
-"b" = (/obj/effect/spawner/structure/window/reinforced/tinted,/turf/open/floor/carpet/black,/area/survivalpod)
+"b" = (/obj/machinery/autolathe,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "c" = (/obj/structure/table/wood/fancy/black,/obj/machinery/light/floor,/obj/machinery/chem_dispenser/drinks/beer,/turf/open/floor/carpet/black,/area/survivalpod)
-"d" = (/obj/structure/closet/cabinet,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"d" = (/obj/machinery/workbench,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "e" = (/obj/machinery/vending/coffee,/turf/open/floor/wood/f13/old,/area/survivalpod)
-"f" = (/obj/structure/bed,/obj/item/bedsheet/captain,/turf/open/floor/carpet/black,/area/survivalpod)
-"g" = (/obj/structure/table/wood/fancy/black,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/mineral/wood/fifty,/turf/open/floor/carpet/black,/area/survivalpod)
+"f" = (/obj/item/twohanded/required/kirbyplants/random,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"g" = (/obj/item/bedsheet/black,/obj/structure/bed,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "h" = (/turf/open/floor/carpet/black,/area/survivalpod)
-"j" = (/obj/machinery/workbench,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"j" = (/obj/structure/rack,/obj/item/stack/sheet/mineral/wood/fifty,/obj/item/stack/sheet/mineral/wood/fifty,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "l" = (/turf/open/floor/wood/f13/old,/area/survivalpod)
 "n" = (/obj/machinery/vending/snack,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "o" = (/obj/machinery/light/floor,/obj/item/twohanded/required/kirbyplants/random,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "t" = (/obj/machinery/light/floor,/obj/item/twohanded/required/kirbyplants/random,/turf/open/floor/carpet/black,/area/survivalpod)
 "w" = (/turf/closed/wall/f13/tentwall,/area/survivalpod)
 "x" = (/obj/structure/table/wood/fancy/black,/obj/machinery/chem_dispenser/drinks,/turf/open/floor/carpet/black,/area/survivalpod)
-"z" = (/obj/structure/chair/wood/fancy{dir = 4},/turf/open/floor/carpet/black,/area/survivalpod)
-"A" = (/obj/structure/table/wood/fancy/black,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"z" = (/obj/structure/bed,/obj/item/bedsheet/black,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"A" = (/obj/structure/dresser,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "D" = (/obj/machinery/vending/cigarette,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "E" = (/obj/structure/chair/wood{dir = 1; icon_state = "wooden_chair_settler"; tag = "icon-wooden_chair_settler (NORTH)"},/turf/open/floor/carpet/black,/area/survivalpod)
-"H" = (/obj/machinery/light/floor,/turf/open/floor/carpet/black,/area/survivalpod)
+"H" = (/obj/structure/campfire/stove,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "J" = (/obj/structure/table/wood/fancy/black,/obj/item/storage/box/ingredients/american,/obj/item/storage/box/ingredients/american,/obj/structure/table/wood/fancy/black,/turf/open/floor/carpet/black,/area/survivalpod)
 "K" = (/obj/machinery/vending/cola/starkist,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "N" = (/obj/structure/displaycase_chassis,/obj/item/stack/sheet/glass/ten,/obj/machinery/light/floor,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "P" = (/obj/structure/simple_door/tent,/turf/open/floor/wood/f13/old,/area/survivalpod)
-"Q" = (/obj/structure/closet/cabinet,/turf/open/floor/carpet/black,/area/survivalpod)
+"Q" = (/obj/structure/rack,/obj/item/stack/sheet/metal/fifty,/obj/item/stack/sheet/plasteel/twenty,/turf/open/floor/wood/f13/old,/area/survivalpod)
 "T" = (/obj/structure/table/wood/fancy/black,/turf/open/floor/carpet/black,/area/survivalpod)
-"V" = (/obj/structure/chair/wood/fancy{dir = 8},/turf/open/floor/carpet/black,/area/survivalpod)
-"X" = (/obj/machinery/autolathe,/turf/open/floor/wood/f13/old,/area/survivalpod)
-"Z" = (/obj/structure/bed,/obj/item/bedsheet/black,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"V" = (/obj/structure/rack,/obj/item/stack/crafting/electronicparts/five,/obj/item/stack/crafting/goodparts/five,/obj/item/stack/crafting/metalparts/five,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"X" = (/obj/structure/closet/cabinet,/turf/open/floor/wood/f13/old,/area/survivalpod)
+"Z" = (/obj/structure/table/wood/fancy/black,/turf/open/floor/wood/f13/old,/area/survivalpod)
 
 (1,1,1) = {"
-aaaaaawwwwwaaaaaa
-aaaaawwfbfwwaaaaa
-aaaawwHhbhHwwaaaa
-aaawwQhhbhhQwwaaa
-aaawohhbbbhhowaaa
-aaawAhhhHhhhAwaaa
-aaawAVhhhhhzAwaaa
-aaawolllllllowaaa
-aaawwwwwPwwwwwaaa
-aaawNKDlllenNwaaa
-wwwwlhhhhhhhlwwww
-wXlPlhgxcJThlPlZw
-wjlwlhhhhhhhlwdZw
-wwwwlhhEhEhhlwwww
-aaawolhhhhhlowaaa
-aaawwwwhhhwwwwaaa
-aaaaaawthtwaaaaaa
-aaaaaawwlwwaaaaaa
-aaaaaaawPwaaaaaaa
+wwwwwwwwwwwwwwwwwww
+wbdwNKDlllenNwfllgw
+wllwlhhhhhhhlwlllzw
+wllPlhTxcJThlPlllAw
+wjlwlhhhhhhhlwlllHw
+wQlwlhhEhEhhlwllllw
+wVlwolhhhhhlowXZZZw
+wwwwwwwhhhwwwwwwwww
+aaaaaawthtwaaaaaaaa
+aaaaaawwlwwaaaaaaaa
+aaaaaaawPwaaaaaaaaa
 "}

--- a/_maps/templates/shelter_7.dmm
+++ b/_maps/templates/shelter_7.dmm
@@ -1,4 +1,6 @@
 "a" = (/obj/structure/fence/corner/wooden{dir = 8},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
+"b" = (/obj/structure/reagent_dispensers/compostbin,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
+"c" = (/obj/structure/legion_extractor,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "f" = (/obj/structure/table/wood,/obj/effect/spawner/lootdrop/f13/foodspawner,/obj/effect/spawner/lootdrop/f13/foodspawner,/turf/open/floor/f13/wood,/area/survivalpod)
 "g" = (/obj/structure/fence/corner/wooden,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "i" = (/obj/structure/fermenting_barrel,/turf/open/floor/f13/wood,/area/survivalpod)
@@ -6,8 +8,10 @@
 "l" = (/obj/structure/table/wood,/obj/item/kitchen/knife,/obj/item/flashlight/lamp,/turf/open/floor/f13/wood,/area/survivalpod)
 "m" = (/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "n" = (/obj/structure/fence/wooden{pixel_y = 2},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
+"q" = (/turf/open/indestructible/ground/outside/dirt,/area/f13/wasteland)
 "r" = (/obj/structure/bed,/obj/item/bedsheet/brown,/turf/open/floor/f13/wood,/area/survivalpod)
 "s" = (/obj/structure/sink/puddle,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
+"t" = (/obj/structure/simple_door/metal/fence,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "u" = (/obj/structure/table/wood,/obj/machinery/microwave,/turf/open/floor/f13/wood,/area/survivalpod)
 "y" = (/turf/closed/wall/f13/tentwall,/area/survivalpod)
 "B" = (/obj/structure/fence/wooden{pixel_y = -8},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
@@ -18,21 +22,22 @@
 "J" = (/obj/structure/simple_door/tent,/turf/open/floor/f13/wood{icon_state = "housewood2"; tag = "icon-housewood2"},/area/survivalpod)
 "L" = (/obj/structure/closet/f13/leigon/plants,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/turf/open/floor/f13/wood,/area/survivalpod)
 "O" = (/turf/open/floor/f13/wood,/area/survivalpod)
+"P" = (/obj/structure/fence/wooden{pixel_y = 2},/obj/structure/fence/wooden{pixel_y = 2},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "Q" = (/obj/structure/fence/corner/wooden{dir = 4},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "S" = (/obj/structure/closet/crate/wooden,/obj/item/shovel/spade,/obj/item/reagent_containers/spray/plantbgone,/obj/item/plant_analyzer,/obj/item/cultivator,/turf/open/floor/f13/wood,/area/survivalpod)
 "V" = (/mob/living/simple_animal/cow/brahmin,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
-"X" = (/obj/structure/reagent_dispensers/compostbin,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
+"X" = (/obj/machinery/smartfridge/bottlerack/seedbin,/turf/open/floor/f13/wood,/area/survivalpod)
 "Z" = (/obj/machinery/vending/hydroseeds,/turf/open/floor/f13/wood,/area/survivalpod)
 
 (1,1,1) = {"
-mmmyyyyyyymmm
-mmmyfuHOrymmm
-msjylOOOLymmm
-mmmyZOOSiymmm
-mmmyyyOyyymmm
-aDDDQyJyaDDDQ
-nGmGmmmmnmVmE
-nXGmmmmmmmmmB
-EGmGmmmmBVmVB
+aDDyyyyyyymmm
+nmmyfuHXrymmm
+nsjylOOOLymmm
+nqqyZOOSiymmm
+ncqyyyOyyymmm
+nbqmmyJyaDDDQ
+PGqGmmmmnmVmE
+nGqGmmmmtmmmB
+EGqGmmmmBVmVB
 aDDDgmmmaDDDg
 "}

--- a/_maps/templates/shelter_7.dmm
+++ b/_maps/templates/shelter_7.dmm
@@ -1,6 +1,4 @@
 "a" = (/obj/structure/fence/corner/wooden{dir = 8},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
-"b" = (/obj/structure/reagent_dispensers/compostbin,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
-"c" = (/obj/structure/legion_extractor,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "f" = (/obj/structure/table/wood,/obj/effect/spawner/lootdrop/f13/foodspawner,/obj/effect/spawner/lootdrop/f13/foodspawner,/turf/open/floor/f13/wood,/area/survivalpod)
 "g" = (/obj/structure/fence/corner/wooden,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "i" = (/obj/structure/fermenting_barrel,/turf/open/floor/f13/wood,/area/survivalpod)
@@ -8,36 +6,38 @@
 "l" = (/obj/structure/table/wood,/obj/item/kitchen/knife,/obj/item/flashlight/lamp,/turf/open/floor/f13/wood,/area/survivalpod)
 "m" = (/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "n" = (/obj/structure/fence/wooden{pixel_y = 2},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
-"q" = (/turf/open/indestructible/ground/outside/dirt,/area/f13/wasteland)
+"p" = (/obj/structure/legion_extractor,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "r" = (/obj/structure/bed,/obj/item/bedsheet/brown,/turf/open/floor/f13/wood,/area/survivalpod)
 "s" = (/obj/structure/sink/puddle,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
-"t" = (/obj/structure/simple_door/metal/fence,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "u" = (/obj/structure/table/wood,/obj/machinery/microwave,/turf/open/floor/f13/wood,/area/survivalpod)
+"v" = (/turf/open/indestructible/ground/outside/dirt,/area/f13/wasteland)
 "y" = (/turf/closed/wall/f13/tentwall,/area/survivalpod)
 "B" = (/obj/structure/fence/wooden{pixel_y = -8},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "D" = (/obj/structure/fence/wooden{dir = 4},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "E" = (/obj/structure/fence/wooden{pixel_y = -8},/obj/structure/fence/wooden{pixel_y = 2},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
+"F" = (/obj/structure/reagent_dispensers/compostbin,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "G" = (/obj/machinery/hydroponics/soil,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "H" = (/obj/machinery/vending/hydronutrients,/turf/open/floor/f13/wood,/area/survivalpod)
 "J" = (/obj/structure/simple_door/tent,/turf/open/floor/f13/wood{icon_state = "housewood2"; tag = "icon-housewood2"},/area/survivalpod)
 "L" = (/obj/structure/closet/f13/leigon/plants,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/obj/item/reagent_containers/food/snacks/grown/wheat,/turf/open/floor/f13/wood,/area/survivalpod)
 "O" = (/turf/open/floor/f13/wood,/area/survivalpod)
-"P" = (/obj/structure/fence/wooden{pixel_y = 2},/obj/structure/fence/wooden{pixel_y = 2},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "Q" = (/obj/structure/fence/corner/wooden{dir = 4},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "S" = (/obj/structure/closet/crate/wooden,/obj/item/shovel/spade,/obj/item/reagent_containers/spray/plantbgone,/obj/item/plant_analyzer,/obj/item/cultivator,/turf/open/floor/f13/wood,/area/survivalpod)
+"T" = (/obj/structure/fence/wooden{pixel_y = 2},/obj/structure/fence/wooden{pixel_y = 2},/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "V" = (/mob/living/simple_animal/cow/brahmin,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "X" = (/obj/machinery/smartfridge/bottlerack/seedbin,/turf/open/floor/f13/wood,/area/survivalpod)
+"Y" = (/obj/structure/simple_door/metal/fence,/turf/open/floor/plating/f13/outside/desert,/area/f13/wasteland)
 "Z" = (/obj/machinery/vending/hydroseeds,/turf/open/floor/f13/wood,/area/survivalpod)
 
 (1,1,1) = {"
 aDDyyyyyyymmm
 nmmyfuHXrymmm
 nsjylOOOLymmm
-nqqyZOOSiymmm
-ncqyyyOyyymmm
-nbqmmyJyaDDDQ
-PGqGmmmmnmVmE
-nGqGmmmmtmmmB
-EGqGmmmmBVmVB
+nvvyZOOSiymmm
+npvyyyOyyymmm
+nFvmmyJyaDDDQ
+TGvGmmmmnmVmE
+nGvGmmmmYmmmB
+EGvGmmmmBVmVB
 aDDDgmmmaDDDg
 "}

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1280,7 +1280,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 //		return
 
 	var/list/dat = list()
+	/*
 	var/total = special_s + special_p + special_e + special_c + special_i + special_a + special_l
+	*/
 	dat += "<center><b>Allocate points</b></center><br>"
 	//dat += "<center>[total] out of 30 possible</center><br>"
 	dat += "<b>Strength	   :</b> <a href='?_src_=prefs;preference=special_s;task=input'>[special_s]</a><BR>"

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -478,8 +478,8 @@
 		adjustHealth(-round(S.get_reagent_amount("uranium") * 0.1))
 		adjustToxic(round(S.get_reagent_amount("uranium") * 0.2))
 	if(S.has_reagent("radium", 1))
-		adjustHealth(-round(S.get_reagent_amount("radium") * 0.1))
-		adjustToxic(round(S.get_reagent_amount("radium") * 0.3)) // Radium is harsher (OOC: also easier to produce)
+		adjustHealth(-round(S.get_reagent_amount("radium") * 0.4))
+		adjustToxic(round(S.get_reagent_amount("radium") * 0.5)) // Radium is harsher (OOC: also easier to produce)
 
 	// Nutriments
 	if(S.has_reagent("eznutriment", 1))


### PR DESCRIPTION

## Description
Shortens the ultra-deluxe tent, addes 2 tiles on the x axis, and removed 10 nearly off the y axis. It should fit better now.

Tweaks to make radium harsher than uranium (give availability and feedback, thanks Dan!)

Updates the farm tent to have the last utilities it needs at a minimum and redraw the fences to the water hole.

Fix compiling error

## Motivation and Context
Bug fixes and community feedback

## How Has This Been Tested?
Clean compiled

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Radium tox/health loss to plants from .1 and .2 to .3 and .4
Farming tent, seed spawner removed, seed vendor replaced due to what the seed spawner has (temp fix)
Farming tent now has its bin and seed extractor
Ultra-deluxe shortened by about 8 tiles on the verticle axis
Compiling error fixed.

/:cl:
