### PR TITLE
Trash cleanup for trash piles

### DIFF
--- a/code/controllers/subsystem/item_spawners.dm
+++ b/code/controllers/subsystem/item_spawners.dm
@@ -6,8 +6,15 @@ SUBSYSTEM_DEF(itemspawners)
 	log_game("Item Spawners Subsystem Firing")
 	message_admins("Item Spawners Subsystem Firing.")
 
+	cleanup_trash()
 	restock_trash_piles()
 
 /datum/controller/subsystem/itemspawners/proc/restock_trash_piles()
 	for(var/obj/item/storage/trash_stack/TS in GLOB.trash_piles)
 		TS.loot_players = list()
+
+/datum/controller/subsystem/itemspawners/proc/cleanup_trash()
+	for(var/obj/item/storage/trash_stack/TS in GLOB.trash_piles)
+		for(var/obj/A in TS.loc.contents)
+			if (!istype(A, /obj/item/storage/trash_stack))
+				A.Destroy()


### PR DESCRIPTION
## Description
Deletes every item on top of the turfs trash piles are located every time they restock.

## Motivation and Context
So we don't end up with 50+ trash items on every single trash stack turf each round.
Might or might not help with performance.

## How Has This Been Tested?
Tested on a 1 minute timer locally, seems to work fine.