### PR TITLE
More scoped weapons

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -1639,7 +1639,7 @@
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
 
-/datum/crafting_recipe/huntingrifle_scoped
+/*/datum/crafting_recipe/huntingrifle_scoped
 	name = "scoped hunting rifle"
 	result = /obj/item/gun/ballistic/shotgun/remington/scoped
 	reqs = list(/obj/item/gun/ballistic/shotgun/remington = 1,
@@ -1650,7 +1650,7 @@
 	time = 120
 	category = CAT_WEAPONRY
 	subcategory = CAT_WEAPON
-
+*/
 /* CRAFT rework: removed for balance
 /datum/crafting_recipe/m1garand
 	name = "M1 Garand"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -355,12 +355,31 @@
 			return
 	return ..()
 
-/obj/item/proc/combine_items(mob/user, obj/item/A, obj/item/B, obj/item/C)
-	visible_message("triggering properly")
-	for(var/obj/item/D in B.contents)
-		var/obj/item/E = D
-		if(istype(D,/obj/item/attachments))		
-			user.transferItemToLoc(E,C)
+/obj/item/gun/proc/combine_items(mob/user, obj/item/gun/A, obj/item/gun/B, obj/item/gun/C)
+	if (B.bullet_speed)
+		C.desc += " It has an improved barrel installed."
+		C.projectile_speed -= 0.15
+	if (B.recoil_decrease)
+		C.desc += " It has a recoil compensator installed."
+		if (C.spread > 8)
+			C.spread -= 8
+		else
+			C.spread = 0
+	for(var/obj/item/D in B.contents)//D - old item
+		if(istype(D,/obj/item/attachments))
+			user.transferItemToLoc(D,C)//old attmns to new gun
+			if (istype(D,/obj/item/attachments/bullet_speed))
+				C.bullet_speed = D
+			if (istype(D,/obj/item/attachments/recoil_decrease))
+				C.recoil_decrease = D
+		/*
+		if(istype(D,/obj/item/ammo_box/magazine))
+			for (var/obj/item/F in C.contents)//F - new mag
+				if(istype(F,/obj/item/ammo_box/magazine))
+					F.forceMove(get_turf(user.loc))//delete old mag
+					F.Destroy()
+					user.transferItemToLoc(D,C)//old mag to new gun
+					*/
 	A.Destroy()
 	B.Destroy()
 	user.put_in_hand(C,user.active_hand_index)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -355,6 +355,16 @@
 			return
 	return ..()
 
+/obj/item/proc/combine_items(mob/user, obj/item/A, obj/item/B, obj/item/C)
+	visible_message("triggering properly")
+	for(var/obj/item/D in B.contents)
+		var/obj/item/E = D
+		if(istype(D,/obj/item/attachments))		
+			user.transferItemToLoc(E,C)
+	A.Destroy()
+	B.Destroy()
+	user.put_in_hand(C,user.active_hand_index)
+
 /obj/item/gun/attackby(obj/item/I, mob/user, params)
 	if(user.a_intent == INTENT_HARM)
 		return ..()
@@ -392,6 +402,25 @@
 	else if(istype(I, /obj/item/attachments/scope))
 		if(!can_scope)
 			return ..()
+		//trail carbine, brush gun, cowboy repeater, .44 revolver, rangemaster, hunting rifle
+		if (istype(src, /obj/item/gun/ballistic/revolver/m29))//weapons with existing scoped variants
+			combine_items(user,I,src, new /obj/item/gun/ballistic/revolver/m29/scoped)//44 revolver
+			return
+		if (istype(src, /obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy))
+			combine_items(user,I,src, new /obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy/scoped)//cowboy repeater
+			return
+		if (istype(src, /obj/item/gun/ballistic/shotgun/automatic/hunting/trail))
+			combine_items(user,I,src, new /obj/item/gun/ballistic/shotgun/automatic/hunting/trail)//trail carbine
+			return
+		if (istype(src, /obj/item/gun/ballistic/shotgun/automatic/hunting/brush))
+			combine_items(user,I,src, new /obj/item/gun/ballistic/shotgun/automatic/hunting/brush/scoped)//brush gun
+			return
+		if (istype(src, /obj/item/gun/ballistic/automatic/rangemaster))
+			combine_items(user,I,src, new /obj/item/gun/ballistic/automatic/rangemaster/scoped)//rangemaster
+			return
+		if (istype(src, /obj/item/gun/ballistic/shotgun/remington))
+			combine_items(user,I,src, new /obj/item/gun/ballistic/shotgun/remington/scoped)//hunting rifle
+			return
 		var/obj/item/attachments/scope/C = I
 		if(!scope)
 			if(!user.transferItemToLoc(I, src))

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -972,6 +972,10 @@
 	en_bloc = 1
 	auto_eject = 1
 	auto_eject_sound = 'sound/f13weapons/garand_ping.ogg'
+	can_bayonet = TRUE
+	bayonetstate = "lasmusket"
+	knife_x_offset = 24
+	knife_y_offset = 24
 
 /obj/item/gun/ballistic/automatic/m1garand/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -999,6 +999,7 @@
 	burst_size = 1
 	fire_delay = 3
 	can_attachments = TRUE
+	can_scope = TRUE
 
 /obj/item/gun/ballistic/automatic/rangemaster/scoped
 	name = "Scoped Colt Rangemaster"
@@ -1009,6 +1010,7 @@
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/automatic/fnfal
 	name = "FN FAL"

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -974,8 +974,8 @@
 	auto_eject_sound = 'sound/f13weapons/garand_ping.ogg'
 	can_bayonet = TRUE
 	bayonetstate = "lasmusket"
-	knife_x_offset = 24
-	knife_y_offset = 24
+	knife_x_offset = 22
+	knife_y_offset = 21
 
 /obj/item/gun/ballistic/automatic/m1garand/update_icon()
 	..()

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -361,16 +361,19 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/cylinder/rev44
 	fire_sound = 'sound/f13weapons/44mag.ogg'
 	fire_delay = 3
+	can_scope = TRUE
 
 /obj/item/gun/ballistic/revolver/m29/alt
 	item_state = "44magnum"
 	icon_state = "mysterious_m29"
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/revolver/m29/coltwalker
-    name = "Colt Walker 1847"
-    desc = "A legendary gun of the west. The Colt Walker bears a fearsome reputation for a very good reason, finding itself in the hands of everyone from ancient army officials to outlaws throughout the years. An antique when the bombs dropped, the weapon is now incredibly outdated. Still, that doesn't make it any less lethal."
-    item_state = "coltwalker"
-    icon_state = "coltwalker"
+	name = "Colt Walker 1847"
+	desc = "A legendary gun of the west. The Colt Walker bears a fearsome reputation for a very good reason, finding itself in the hands of everyone from ancient army officials to outlaws throughout the years. An antique when the bombs dropped, the weapon is now incredibly outdated. Still, that doesn't make it any less lethal."
+	item_state = "coltwalker"
+	icon_state = "coltwalker"
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/revolver/m29/peacekeeper
 	name = "Peacekeeper"
@@ -384,6 +387,7 @@
 	burst_delay = 1
 	var/select = 0
 	actions_types = list(/datum/action/item_action/toggle_firemode)
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/revolver/m29/peacekeeper/ui_action_click()
 	burst_select()
@@ -414,6 +418,7 @@
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/revolver/colt357
 	name = "\improper .357 magnum revolver"

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -387,6 +387,7 @@ TODO sprite, ignore for now*/
 	fire_delay = 3
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
+	can_scope = TRUE
 
 /obj/item/gun/ballistic/shotgun/remington/attackby(obj/item/A, mob/user, params)
 	..()
@@ -409,6 +410,7 @@ TODO sprite, ignore for now*/
 	zoomable = TRUE
 	zoom_amt = 10
 	zoom_out_amt = 13
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/shotgun/remington/scoped/paciencia
 	name = "Paciencia"
@@ -460,6 +462,7 @@ TODO sprite, ignore for now*/
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 4
+	can_scope = TRUE
 
 /obj/item/gun/ballistic/shotgun/automatic/hunting/trail/scoped
 	name = "scoped trail carbine"
@@ -475,6 +478,7 @@ TODO sprite, ignore for now*/
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 6
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy
 	name = "cowboy repeater"
@@ -487,6 +491,7 @@ TODO sprite, ignore for now*/
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 6
+	can_scope = TRUE
 
 /obj/item/gun/ballistic/shotgun/automatic/hunting/cowboy/scoped
 	name = "scoped cowboy repeater"
@@ -502,6 +507,7 @@ TODO sprite, ignore for now*/
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 8
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/shotgun/automatic/hunting/brush
 	name = "brush gun"
@@ -513,6 +519,7 @@ TODO sprite, ignore for now*/
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 6
+	can_scope = TRUE
 
 /obj/item/gun/ballistic/shotgun/automatic/hunting/brush/scoped
 	name = "scoped brush gun"
@@ -527,6 +534,7 @@ TODO sprite, ignore for now*/
 	w_class = WEIGHT_CLASS_BULKY
 	weapon_weight = WEAPON_HEAVY
 	fire_delay = 8
+	can_scope = FALSE
 
 /obj/item/gun/ballistic/revolver/widowmaker
 	name = "winchester widowmaker"


### PR DESCRIPTION
## Description
Allows for the crafting of scoped weapons with existing scoped variants by attaching a scope.
Includes the trail carbine, brush gun, cowboy repeater, .44 revolver, rangemaster, and hunting rifle

Also a bayonet for the M1 since someone asked.
![image](https://user-images.githubusercontent.com/67761424/91003065-472dd180-e59e-11ea-963e-7a74b8dcf4b8.png)

## Motivation and Context
Hey it makes sense.

## How Has This Been Tested?
Works, tested attachments transferring properly, will figure something out for ammo in a later patch possibly.