### PR TITLE
Hotkeys

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -34,6 +34,7 @@ SUBSYSTEM_DEF(input)
 			"O" = "ooc",
 			"T" = "say",
 			"M" = "me",
+			"U" = "surrender",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",
@@ -49,6 +50,7 @@ SUBSYSTEM_DEF(input)
 			"O" = "ooc",
 			"T" = "say",
 			"M" = "me",
+			"U" = "surrender",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs
 			"Any" = "\"KeyDown \[\[*\]\]\"",
 			"Any+UP" = "\"KeyUp \[\[*\]\]\"",

--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -81,7 +81,7 @@
 			return
 	return ..()
 
-/mob/key_down(_key, client/user)
+/mob/key_down(_key, client/user)//hotkeys for stuff
 	switch(_key)
 		if("T")
 			src.set_typing_indicator(TRUE)
@@ -89,4 +89,6 @@
 			src.set_typing_indicator(TRUE)
 		if("C")
 			src/living.toggle_combat_mode()
+		if("N")
+			src.toggle_typing_indicator()
 	return ..()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -96,5 +96,6 @@
 		S.sharerDies(gibbed)
 
 	set_typing_indicator(FALSE) //SKYRAT CHANGE
+	change_combat_indicator(FALSE)
 	
 	return TRUE

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -366,4 +366,4 @@
 
 /mob/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	. = ..()
-	set_typing_indicator(FALSE)
+	//set_typing_indicator(FALSE)

--- a/code/modules/mob/typing_indicator.dm
+++ b/code/modules/mob/typing_indicator.dm
@@ -85,3 +85,9 @@ GLOBAL_LIST_EMPTY(typing_indicator_overlays)
 		return
 	if(!hud_typing)
 		set_typing_indicator(FALSE) 
+
+/mob/proc/toggle_typing_indicator()
+	if(typing)
+		set_typing_indicator(FALSE)
+	else
+		set_typing_indicator(TRUE)


### PR DESCRIPTION
## Description
Couple of hotkey and indicator changes.
Typing indicator no longer disappears when moving, instead it can be toggled on and off manually with "N" when necessary.
Surrender verb has been bound to "U".
Combat indicator now properly disappears on death.

## Motivation and Context
Hotkey changes were suggested by Char and seconded by some others, should allow for surrendering while in combat with less risk of death.
Chat bubble hotkey both to simplify toggling it off for players that wish to cancel their chats/emotes and to allow toggling it on for things like whispers, subtle, etc.