### PR TITLE
Updates scope attaching to transfer ammo.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -356,6 +356,7 @@
 	return ..()
 
 /obj/item/gun/proc/combine_items(mob/user, obj/item/gun/A, obj/item/gun/B, obj/item/gun/C)
+
 	if (B.bullet_speed)
 		C.desc += " It has an improved barrel installed."
 		C.projectile_speed -= 0.15
@@ -365,21 +366,19 @@
 			C.spread -= 8
 		else
 			C.spread = 0
+	
 	for(var/obj/item/D in B.contents)//D - old item
 		if(istype(D,/obj/item/attachments))
 			user.transferItemToLoc(D,C)//old attmns to new gun
-			if (istype(D,/obj/item/attachments/bullet_speed))
+			if(istype(D,/obj/item/attachments/bullet_speed))
 				C.bullet_speed = D
-			if (istype(D,/obj/item/attachments/recoil_decrease))
+			if(istype(D,/obj/item/attachments/recoil_decrease))
 				C.recoil_decrease = D
-		/*
 		if(istype(D,/obj/item/ammo_box/magazine))
-			for (var/obj/item/F in C.contents)//F - new mag
-				if(istype(F,/obj/item/ammo_box/magazine))
-					F.forceMove(get_turf(user.loc))//delete old mag
-					F.Destroy()
-					user.transferItemToLoc(D,C)//old mag to new gun
-					*/
+			for(var/obj/item/ammo_box/magazine/X in C.contents)
+				var/obj/item/ammo_box/magazine/oldmag = D
+				X.stored_ammo = oldmag.stored_ammo
+				X.contents = oldmag.contents
 	A.Destroy()
 	B.Destroy()
 	user.put_in_hand(C,user.active_hand_index)


### PR DESCRIPTION
## Description
Transfers the amount/type of ammo from the old weapon to the new when crafting a scoped variant.

## Motivation and Context
Was needed in the first place, but couldn't figure it out yesterday.