### PR TITLE
Trapper quirk

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -67,6 +67,7 @@
 #define TRAIT_PROSOPAGNOSIA		"prosopagnosia"
 #define	TRAIT_DRUNK_HEALING		"drunk_healing"
 #define TRAIT_BIG_LEAGUES		"big_leagues"
+#define TRAIT_TRAPPER			"trapper"
 #define TRAIT_IRONFIST			"iron_fist"
 #define TRAIT_PSYCHO			"psycho"
 #define	TRAIT_LIFEGIVER			"lifegiver"

--- a/code/datums/components/butchering.dm
+++ b/code/datums/components/butchering.dm
@@ -34,6 +34,8 @@
 				for(var/i in 1 to 2)
 					new bones (T)
 			else
+				if (butcher.has_trait(TRAIT_TRAPPER))
+					new bones (T)
 				new bones (T)
 		meat.butcher_results.Remove(bones) //in case you want to, say, have it drop its results on gib
 	for(var/V in meat.guaranteed_butcher_results)

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -26,6 +26,14 @@
 		if(mood)
 			mood.mood_modifier = 1 //Change this once/if species get their own mood modifiers.
 
+/datum/quirk/trapper
+	name = "Trapper"
+	desc = "As an experienced hunter and trapper you know your way around butchering animals for their products, and are able to get twice the usable materials by eliminating waste."
+	value = 2
+	mob_trait = TRAIT_TRAPPER
+	gain_text = "<span class='notice'>You learn the secrets of butchering!</span>"
+	lose_text = "<span class='danger'>You forget how to slaughter animals.</span>"
+
 /datum/quirk/bigleagues
 	name = "Big Leagues"
 	desc = "Swing for the fences! You deal additional damage with melee weapons."


### PR DESCRIPTION
## Description
Allows butchering with double results, costs 2 points.

## Motivation and Context
More noncombat perks, now even more useful with leather being worth caps.
Seems to work properly in game, ghouls and geckos dropping 2 skins.