### PR TITLE
Runtime error fix

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -3493,12 +3493,6 @@
 "km" = (
 /turf/closed/wall/f13/tunnel,
 /area/centcom/evac)
-"kn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/evac)
 "ko" = (
 /turf/closed/indestructible/abductor{
 	icon_state = "alien20"
@@ -3601,7 +3595,6 @@
 	name = "Shower"
 	},
 /obj/item/soap/deluxe,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/centcom/evac)
 "kD" = (
@@ -3756,12 +3749,6 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/f13/vault,
 /area/centcom/evac)
-"kU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/centcom/evac)
 "kV" = (
 /obj/structure/sink{
 	dir = 4;
@@ -3769,9 +3756,6 @@
 	},
 /obj/structure/mirror{
 	pixel_x = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/evac)
@@ -3871,13 +3855,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"lf" = (
-/obj/machinery/door/airlock/silver{
-	name = "Bathroom"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
 /area/centcom/evac)
 "lg" = (
 /turf/closed/indestructible/abductor{
@@ -4110,12 +4087,6 @@
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
-	},
-/area/centcom/evac)
-"lQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
 	},
 /area/centcom/evac)
 "lR" = (
@@ -4481,10 +4452,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
-"mP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/centcom/evac)
 "mQ" = (
 /obj/structure/table/wood,
 /obj/item/clipboard,
@@ -4496,28 +4463,10 @@
 /obj/item/stamp,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
-"mR" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/evac)
-"mS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/evac)
 "mT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
 	req_access_txt = "109"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -4527,9 +4476,6 @@
 /obj/structure/chair/comfy/brown{
 	color = "#596479";
 	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
@@ -4698,15 +4644,6 @@
 	dir = 5
 	},
 /area/centcom/evac)
-"nq" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/evac)
 "nr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -4746,10 +4683,6 @@
 "nv" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
 "nw" = (
@@ -4758,9 +4691,6 @@
 	},
 /obj/machinery/light_switch{
 	pixel_x = 24
-	},
-/obj/structure/cable/white{
-	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
 	dir = 4;
@@ -4913,36 +4843,10 @@
 	dir = 8
 	},
 /area/centcom/evac)
-"nP" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/centcom/evac)
-"nQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/centcom/evac)
-"nR" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/wood,
-/area/centcom/evac)
-"nS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/centcom/evac)
 "nT" = (
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
@@ -5202,13 +5106,6 @@
 	dir = 8
 	},
 /area/centcom/evac)
-"ot" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/vault,
-/area/centcom/evac)
 "ou" = (
 /obj/structure/table/wood,
 /obj/item/storage/secure/briefcase{
@@ -5265,27 +5162,12 @@
 /obj/machinery/ai_status_display,
 /turf/closed/indestructible/riveted,
 /area/tdome/tdomeobserve)
-"oA" = (
-/obj/machinery/door/airlock/centcom{
-	name = "Administrative Office";
-	req_access_txt = "109"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/centcom/evac)
 "oB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
 	req_access_txt = "109"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "oC" = (
@@ -5497,17 +5379,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
-"pb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"pc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "pd" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/item/weldingtool/experimental,
@@ -5610,60 +5481,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"po" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"pq" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"pr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"ps" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
-"pt" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "pu" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Equipment Room";
 	req_access_txt = "150"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -5671,10 +5492,6 @@
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "pv" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
@@ -5689,17 +5506,11 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
 /obj/structure/cable/white{
 	icon_state = "0-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "0-2"
 	},
 /obj/structure/cable/white{
 	icon_state = "0-8"
@@ -5709,15 +5520,8 @@
 	},
 /area/centcom/evac)
 "px" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
 /obj/structure/cable/white{
 	icon_state = "1-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -5804,56 +5608,26 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
-"pL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/centcom/evac)
 "pM" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/portable_atmospherics/canister/air,
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "pN" = (
-/obj/machinery/computer/monitor/secret{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "pO" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 1
-	},
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "pP" = (
@@ -5952,9 +5726,6 @@
 	name = "Administrative Office";
 	req_access_txt = "109"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/evac)
 "qd" = (
@@ -6000,20 +5771,7 @@
 	name = "Commander's Office APC";
 	pixel_x = -26
 	},
-/obj/structure/cable/white{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plasteel/vault,
-/area/centcom/evac)
-"qj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault,
-/area/centcom/evac)
-"qk" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
 "ql" = (
 /obj/structure/table/wood,
@@ -6293,9 +6051,6 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /turf/open/floor/wood,
 /area/centcom/evac)
 "qV" = (
@@ -6451,7 +6206,6 @@
 /area/centcom/evac)
 "ru" = (
 /obj/structure/chair/comfy/black,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
 "rw" = (
@@ -6699,9 +6453,6 @@
 	pixel_y = 5
 	},
 /obj/item/gun/energy/pulse/pistol/m1911,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/evac)
 "sd" = (
@@ -7596,9 +7347,6 @@
 "uy" = (
 /obj/machinery/light{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
 	},
 /turf/open/floor/wood,
 /area/centcom/evac)
@@ -44649,15 +44397,15 @@ jU
 lM
 mL
 mL
-kn
+mL
 oo
 jU
 kf
-po
-pc
+kf
+kf
 qb
-nq
-qj
+tH
+tH
 ru
 sc
 sR
@@ -44906,11 +44654,11 @@ jU
 lN
 mM
 nr
-nQ
+mL
 op
 ls
 oL
-ps
+kf
 pB
 jU
 qU
@@ -45163,11 +44911,11 @@ jU
 lO
 mN
 ns
-nP
-mP
-oA
-pb
-pq
+mL
+mL
+oB
+kf
+kf
 kf
 jU
 uy
@@ -45420,14 +45168,14 @@ jU
 lP
 mO
 nt
-nQ
+mL
 oq
 jU
 kf
-ps
+kf
 kf
 jU
-mS
+nB
 qX
 rw
 sq
@@ -45672,19 +45420,19 @@ rb
 rb
 kl
 kB
-kU
-lf
-lQ
-mP
-mP
-nR
+rp
+sJ
+Cc
+mL
+mL
+mL
 or
 ls
 oL
-pr
-pL
+kf
+pB
 jU
-qk
+nB
 nB
 Ag
 sr
@@ -45934,11 +45682,11 @@ jU
 lR
 mQ
 nu
-mS
+nB
 os
 kl
 kf
-ps
+kf
 kf
 jU
 jU
@@ -46189,13 +45937,13 @@ jU
 jU
 lr
 lS
-mR
+nt
 nv
-nS
-ot
+nB
+tH
 oB
-pc
-pt
+kf
+kf
 kf
 jU
 jU
@@ -46446,13 +46194,13 @@ rb
 rb
 ls
 lT
-mS
+nB
 nw
 nT
 ou
 jU
 oL
-ps
+kf
 kf
 iT
 rb
@@ -46709,7 +46457,7 @@ jU
 jU
 jU
 kf
-ps
+kf
 kf
 iT
 rb
@@ -46960,13 +46708,13 @@ rb
 rb
 jU
 lU
-mS
+nB
 nA
 nU
 ov
 ls
 kf
-ps
+kf
 kf
 jU
 jU
@@ -47223,7 +46971,7 @@ nB
 ow
 oC
 oL
-ps
+kf
 kf
 pn
 kf
@@ -47480,7 +47228,7 @@ nV
 ox
 lr
 kf
-ps
+kf
 kf
 lA
 kf
@@ -47737,7 +47485,7 @@ jU
 jU
 jU
 kf
-ps
+kf
 kf
 jU
 jU


### PR DESCRIPTION


## Description
Fixes the runtime error spam in the pipenet subsystem

## Motivation and Context
Bugfixes

## How Has This Been Tested?
Tested on compile, no longer a runtime error
## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Removed unneeded pipes from the map (as we dont use atmos pipes) 
/:cl:
