### PR TITLE
Runtime error fix

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -576,7 +576,8 @@
 	STR.max_items = 8
 
 /obj/item/storage/box/snappops/PopulateContents()
-	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_FILL_TYPE, /obj/item/toy/snappop)
+	for(var/i in 1 to 8)
+		new /obj/item/match(src)
 
 /obj/item/storage/box/matches
 	name = "matchbox"
@@ -594,7 +595,8 @@
 	STR.can_hold = typecacheof(list(/obj/item/match))
 
 /obj/item/storage/box/matches/PopulateContents()
-	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_FILL_TYPE, /obj/item/match)
+	for(var/i in 1 to 8)
+		new /obj/item/match(src)
 
 /obj/item/storage/box/matches/attackby(obj/item/match/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/match))


### PR DESCRIPTION


## Description
Fixes an error in the matchbox populate content field

## Motivation and Context
Bugfixes
## How Has This Been Tested?
Clean compiled, doesnt show in the compiler

## Screenshots (if appropriate):

## Changelog (necessary)
:cl:
Switched matchbox population (and snapop) from a signal send to a basic for-loop
/:cl:
