### PR TITLE
Fixes job.dm:157, supersedes #802

### DIFF
--- a/code/modules/jobs/job_types/ncr.dm
+++ b/code/modules/jobs/job_types/ncr.dm
@@ -584,7 +584,7 @@ Recruit
 	faction = "NCR"
 	total_positions = 8
 	spawn_positions = 8
-	access = null
+	access = list()
 	description = "As an NCR Citizen, you may believe that the potential for fortune out west has dried up and that the frontier holds abundant opportunities for you to encroach and take advantage of. Surrounded by the relative safety of the Republic, you are responsible for being a part of the cities community and maintaining the facilities within it in any capacity which will aid the greater good. You may correspond with the Administrator or other NCR leadership to help them achieve goals, or pursue your own individual goals as an independent agent of the NCR.."
 	supervisors = "NCR Administrator"
 	selection_color = "#fff5cc"


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes an issue where `access` was assigned `null` instead of `list()`. I might go and change all instances of `access = list()` to null and convert it to use `LAZYLEN` eventually, but for now this is a better solution than a null check.

## Motivation and Context
Fixes a runtime on line 157 of job.dm.

## How Has This Been Tested?
N/A

## Screenshots (if appropriate):
N/A

## Changelog (necessary)
:cl:
fix: Fixes a runtime on line 157 of job.dm.
/:cl:
