### PR TITLE
Fixes seven typos.

### DIFF
--- a/code/modules/crafting/items.dm
+++ b/code/modules/crafting/items.dm
@@ -196,37 +196,37 @@
 //plasma
 /obj/item/advanced_crafting_components/flux
 	name = "Flux capacitator"
-	desc = "An energy weapon part, a crafstman might want to have this."
+	desc = "An energy weapon part, a craftsman might want to have this."
 	icon_state = "flux"
 
 //lasers
 /obj/item/advanced_crafting_components/lenses
 	name = "Focused crystal lenses"
-	desc = "An energy weapon part, a crafstman might want to have this."
+	desc = "An energy weapon part, a craftsman might want to have this."
 	icon_state = "lenses"
 
 //general energy
 /obj/item/advanced_crafting_components/conductors
 	name = "Superconductor coil"
-	desc = "An energy weapon part, a crafstman might want to have this."
+	desc = "An energy weapon part, a craftsman might want to have this."
 	icon_state = "conductor"
 
 //general ballistics
 /obj/item/advanced_crafting_components/receiver
 	name = "Advanced modular receiver"
-	desc = "A ballistic weapon part, a crafstman might want to have this."
+	desc = "A ballistic weapon part, a craftsman might want to have this."
 	icon_state = "receiver"
 
 //rifles
 /obj/item/advanced_crafting_components/assembly
 	name = "Pre-war weapon assembly"
-	desc = "A ballistic weapon part, a crafstman might want to have this."
+	desc = "A ballistic weapon part, a craftsman might want to have this."
 	icon_state = "weapon_parts_1"
 
 //general
 /obj/item/advanced_crafting_components/alloys
 	name = "Superlight alloys"
-	desc = "A general crafting part, a crafstman might want to have this."
+	desc = "A general crafting part, a craftsman might want to have this."
 	icon_state = "alloys"
 
 /obj/item/attachments

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -53,7 +53,7 @@
 	if (special_a<3)
 		msg += "<br>Maladroit and unbalanced, it is a wonder they can even stand straight."
 	if (special_l<3)
-		msg += "<br>Unfortune just seems to stick to them like a fly to shit."
+		msg += "<br>Misfortune just seems to stick to them like a fly to shit."
 
 	if (special_s>7)
 		msg += "<br>Simply built out of muscle, they could wrestle a deathclaw to death."


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes six duplicate typos and another in the low-luck SPECIAL message.

## Motivation and Context
Typos.

## How Has This Been Tested?
It's a typo. It's fixed.

## Screenshots (if appropriate):
N/A

## Changelog (necessary)
:cl:
fix: Fixes a typo in the low-luck SPECIAL description.
fix: Fixes typos in the description of some advanced crafting components.
/:cl:
