### PR TITLE
Pixel shifting

### DIFF
--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -61,16 +61,28 @@
 	if(client.keys_held["Ctrl"])
 		switch(SSinput.movement_keys[_key])
 			if(NORTH)
-				northface()
+				if(client.keys_held["Shift"])
+					northshift()
+				else
+					northface()
 				return
 			if(SOUTH)
-				southface()
+				if(client.keys_held["Shift"])
+					southshift()
+				else
+					southface()
 				return
 			if(WEST)
-				westface()
+				if(client.keys_held["Shift"])
+					westshift()
+				else
+					westface()
 				return
 			if(EAST)
-				eastface()
+				if(client.keys_held["Shift"])
+					eastshift()
+				else
+					eastface()
 				return
 	return ..()
 

--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -364,6 +364,50 @@
 		for(var/obj/screen/mov_intent/selector in hud_used.static_inventory)
 			selector.toggle(src)
 
+/mob
+	var/is_shifted = FALSE
+
 /mob/Moved(atom/OldLoc, Dir, Forced = FALSE)
 	. = ..()
 	//set_typing_indicator(FALSE)
+	if(is_shifted)
+		is_shifted = FALSE
+		if(ishuman(src))
+			var/mob/living/M = src
+			pixel_x = M.get_standard_pixel_x_offset(lying) //these are mob/living level procs and this can be triggered by anyone (pointlessly)
+			pixel_y = M.get_standard_pixel_y_offset(lying)
+		else
+			pixel_x = 0
+			pixel_y = 0
+
+/mob/verb/eastshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x <= 16)
+		pixel_x++
+		is_shifted = TRUE
+
+/mob/verb/westshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x >= -16)
+		pixel_x--
+		is_shifted = TRUE
+
+/mob/verb/northshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y <= 16)
+		pixel_y++
+		is_shifted = TRUE
+
+/mob/verb/southshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y >= -16)
+		pixel_y--
+		is_shifted = TRUE


### PR DESCRIPTION
## Description
Hold ctrl + shift and tap wasd to shift your sprite up to 16 in any direction, letting you sit in laps or share chairs or whatever. Doesn't work when resting but you can rest afterwards

## Motivation and Context
It's cool!

## How Has This Been Tested?
Seems to work fine

## Screenshots (if appropriate):
https://i.imgur.com/BkTbrYS.png

## Changelog (necessary)
:cl:
add: Added pixel shifting of your sprite via ctrl + shift + wasd
/:cl:
