### PR TITLE
Jousting/charging update

### DIFF
--- a/code/datums/components/jousting.dm
+++ b/code/datums/components/jousting.dm
@@ -1,19 +1,21 @@
 /datum/component/jousting
 	var/current_direction = NONE
-	var/max_tile_charge = 5
-	var/min_tile_charge = 2				//tiles before this code gets into effect.
-	var/current_tile_charge = 0
-	var/movement_reset_tolerance = 2			//deciseconds
-	var/unmounted_damage_boost_per_tile = 0
-	var/unmounted_knockdown_chance_per_tile = 0
-	var/unmounted_knockdown_time = 0
-	var/mounted_damage_boost_per_tile = 2
-	var/mounted_knockdown_chance_per_tile = 20
-	var/mounted_knockdown_time = 20
-	var/requires_mob_riding = TRUE			//whether this only works if the attacker is riding a mob, rather than anything they can buckle to.
-	var/requires_mount = TRUE				//kinda defeats the point of jousting if you're not mounted but whatever.
+	var/max_tile_charge = 10
+	var/min_tile_charge = 4				//tiles before this code gets into effect.
+	var/movement_reset_tolerance = 3			//deciseconds
+	var/unmounted_damage_boost_per_tile = 5 //also a percentage - 5% per tile, up to 10
+	var/unmounted_knockdown_chance_per_tile = 5 //up to 50%
+	var/unmounted_knockdown_time = 10 //not super strong by default
+	var/mounted_damage_boost_per_tile = 20 //this is going to be a percentage now
+	var/mounted_knockdown_chance_per_tile = 20 // This is 100% at 5 tiles
+	var/mounted_knockdown_time = 50
+	var/requires_mob_riding = FALSE			//whether this only works if the attacker is riding a mob, rather than anything they can buckle to.
+	//^^ HELLO: CHAIR EXTINGUISHER JOUSTING ANYONE??
+	var/requires_mount = FALSE 			//kinda defeats the point of jousting if you're not mounted but whatever.
+	//^^ WRONG: charge attacks babyyy
 	var/mob/current_holder
 	var/current_timerid
+	var/current_tile_charge = 0
 
 /datum/component/jousting/Initialize()
 	if(!isitem(parent))
@@ -32,6 +34,8 @@
 	current_direction = NONE
 	current_tile_charge = 0
 
+//This does a "bonus hit" on people you're striking that can knockdown
+//Damage is based on % charged up and uses the force of the weapon
 /datum/component/jousting/proc/on_attack(mob/living/target, mob/user)
 	if(user != current_holder)
 		return
@@ -40,23 +44,53 @@
 	var/target_buckled = target.buckled ? TRUE : FALSE			//we don't need the reference of what they're buckled to, just whether they are.
 	if((requires_mount && ((requires_mob_riding && !ismob(user.buckled)) || (!user.buckled))) || !current_direction || (current_tile_charge < min_tile_charge))
 		return
+	if(user.get_active_held_item() != parent) //We need to be wielding our weapon to get this bonus hit
+		return
 	var/turf/target_turf = get_step(user, current_direction)
-	if(target in range(1, target_turf))
+	if(target in range(2, target_turf))
 		var/knockdown_chance = (target_buckled? mounted_knockdown_chance_per_tile : unmounted_knockdown_chance_per_tile) * current
 		var/knockdown_time = (target_buckled? mounted_knockdown_time : unmounted_knockdown_time)
 		var/damage = (target_buckled? mounted_damage_boost_per_tile : unmounted_damage_boost_per_tile) * current
+		damage = (damage / 100) * I.force //turn it into a percentage boost of our weapon force
 		var/sharp = I.is_sharp()
 		var/msg
+		var/damtype = STAMINA //Default
+		playsound(get_turf(user), 'sound/weapons/punch4.ogg', 50, 1)
 		if(damage)
 			msg += "[user] [sharp? "impales" : "slams into"] [target] [sharp? "on" : "with"] their [parent]"
-			target.apply_damage(damage, BRUTE, user.zone_selected, 0)
-		if(prob(knockdown_chance))
+			if(istype(parent,/obj)) //All these have damtypes
+				var/obj/P = parent //typecast it
+				damtype = P.damtype
+			target.apply_damage(damage, damtype, user.zone_selected, 0)
+			if(current_tile_charge)
+				current_tile_charge /= 2
+
+		if(target && prob(knockdown_chance))
+			if(!damage)
+				msg += "[user] hits"
 			msg += " and knocks [target] [target_buckled? "off of [target.buckled]" : "down"]"
 			if(target_buckled)
 				target.buckled.unbuckle_mob(target)
 			target.Knockdown(knockdown_time)
+			step_away(target,user)
+			if(current >= max_tile_charge && prob(knockdown_chance / 2))
+				if(target) //Make sure they're still alive
+					target.Unconscious(30)
+			if(current_tile_charge)
+				current_tile_charge /= 2 //Halve it again if we knockdown, so drops to 25% after we land a hit
 		if(length(msg))
-			user.visible_message("<span class='danger'>[msg]!</span>")
+			var/span
+			if(current < 3)
+				span = "'notice'"
+			else if(current < 5)
+				span = "'caution'"
+			else if(current < 7)
+				span = "'warning'"
+			else if(current < 9)
+				span = "'danger'"
+			else
+				span = "'userdanger'"
+			user.visible_message("<span class=[span]>[msg]!</span>")
 
 /datum/component/jousting/proc/mob_move(newloc, dir)
 	if(!current_holder || (requires_mount && ((requires_mob_riding && !ismob(current_holder.buckled)) || (!current_holder.buckled))))
@@ -64,8 +98,10 @@
 	if(dir != current_direction)
 		current_tile_charge = 0
 		current_direction = dir
-	if(current_tile_charge < max_tile_charge)
+	if(current_tile_charge < max_tile_charge && (current_holder.get_active_held_item() == parent)) //Make sure we're wielding our weapon and not just wearing it
 		current_tile_charge++
+		if(current_tile_charge == min_tile_charge) //Should only trigger once
+			to_chat(current_holder,"<span class='notice'>You begin building up momentum!</span>")
 	if(current_timerid)
 		deltimer(current_timerid)
 	current_timerid = addtimer(CALLBACK(src, .proc/reset_charge), movement_reset_tolerance, TIMER_STOPPABLE)

--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -5,10 +5,11 @@
 	icon_state = "mop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
-	force = 3
+	force = 15
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 7
+	damtype = STAMINA
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("mopped", "bashed", "bludgeoned", "whacked")
 	resistance_flags = FLAMMABLE
@@ -23,6 +24,16 @@
 	..()
 	create_reagents(mopcap)
 
+
+/obj/item/mop/Initialize()
+	. = ..()
+	var/datum/component/jousting/JC = AddComponent(/datum/component/jousting)
+	JC.unmounted_damage_boost_per_tile = 1
+	JC.unmounted_knockdown_chance_per_tile = 15
+	JC.unmounted_knockdown_time = 50
+	JC.mounted_damage_boost_per_tile = 5
+	JC.mounted_knockdown_chance_per_tile = 25
+	JC.mounted_knockdown_time = 80
 
 /obj/item/mop/proc/clean(turf/A)
 	if(reagents.has_reagent("water", 1) || reagents.has_reagent("holywater", 1) || reagents.has_reagent("vodka", 1) || reagents.has_reagent("cleaner", 1))
@@ -83,7 +94,7 @@
 	item_state = "mop"
 	lefthand_file = 'icons/mob/inhands/equipment/custodial_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/custodial_righthand.dmi'
-	force = 6
+	force = 25 //It's stamina damage
 	throwforce = 8
 	throw_range = 4
 	mopspeed = 45
@@ -94,6 +105,16 @@
 /obj/item/mop/advanced/New()
 	..()
 	START_PROCESSING(SSobj, src)
+
+/obj/item/mop/advanced/Initialize()
+	. = ..()
+	GET_COMPONENT(JC,/datum/component/jousting) //Actually excellent for jousting/charging
+	JC.unmounted_damage_boost_per_tile = 5
+	JC.unmounted_knockdown_chance_per_tile = 25
+	JC.unmounted_knockdown_time = 30
+	JC.mounted_damage_boost_per_tile = 10
+	JC.mounted_knockdown_chance_per_tile = 30
+	JC.mounted_knockdown_time = 100
 
 /obj/item/mop/advanced/attack_self(mob/user)
 	refill_enabled = !refill_enabled

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -29,6 +29,14 @@
 	var/wieldsound = null
 	var/unwieldsound = null
 
+/obj/item/twohanded/Initialize()
+	. = ..()
+	var/datum/component/jousting/JC = AddComponent(/datum/component/jousting) //Oh yeah. We can modify and tweak this for individual items
+	JC.mounted_damage_boost_per_tile = 25 //Percentage of weapon force on the bonus hit
+	JC.mounted_knockdown_chance_per_tile = 25 // This is 100% at 4 tiles
+	JC.mounted_knockdown_time = 60
+
+
 /obj/item/twohanded/proc/unwield(mob/living/carbon/user, show_message = TRUE)
 	if(!wielded || !user)
 		return
@@ -221,11 +229,11 @@
 	righthand_file = 'icons/mob/inhands/weapons/axes_righthand.dmi'
 	name = "woodaxe"
 	desc = "The axe forgets what the tree remembers."
-	force = 5
+	force = 25
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
-	force_unwielded = 10
+	force_unwielded = 25
 	force_wielded = 50
 	attack_verb = list("axed", "chopped", "cleaved", "torn", "hacked")
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -237,6 +245,14 @@
 /obj/item/twohanded/fireaxe/Initialize()
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 80, 0 , hitsound) //axes are not known for being precision butchering tools
+	GET_COMPONENT(JC,/datum/component/jousting)
+	JC.movement_reset_tolerance = 4
+	JC.unmounted_damage_boost_per_tile = 25
+	JC.unmounted_knockdown_chance_per_tile = 25
+	JC.unmounted_knockdown_time = 5
+	JC.mounted_damage_boost_per_tile = 25
+	JC.mounted_knockdown_chance_per_tile = 25
+	JC.mounted_knockdown_time = 30
 
 /obj/item/twohanded/fireaxe/update_icon()  //Currently only here to fuck with the on-mob icons.
 	icon_state = "fireaxe[wielded]"
@@ -268,13 +284,13 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	name = "double-bladed energy sword"
 	desc = "Handle with care."
-	force = 3
+	force = 25
 	throwforce = 5
 	throw_speed = 3
 	throw_range = 5
 	w_class = WEIGHT_CLASS_SMALL
 	var/w_class_on = WEIGHT_CLASS_BULKY
-	force_unwielded = 3
+	force_unwielded = 25
 	force_wielded = 34
 	wieldsound = 'sound/weapons/saberon.ogg'
 	unwieldsound = 'sound/weapons/saberoff.ogg'
@@ -457,7 +473,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	name = "improvised metal glaive"
 	desc = "A improvised metal glaive that can be wielded."
-	force = 10
+	force = 25
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	force_unwielded = 25
@@ -490,10 +506,6 @@
 		qdel(src)
 		return BRUTELOSS
 	return BRUTELOSS
-
-/obj/item/twohanded/spear/Initialize()
-	. = ..()
-	AddComponent(/datum/component/jousting)
 
 /obj/item/twohanded/spear/examine(mob/user)
 	..()
@@ -563,7 +575,7 @@
 	inhand_x_dimension = 64
 	inhand_y_dimension = 64
 	slot_flags = ITEM_SLOT_BACK
-	force = 10
+	force = 5
 	var/force_on = 60
 	w_class = WEIGHT_CLASS_BULKY
 	throwforce = 20
@@ -791,6 +803,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	name = "high frequency blade"
 	desc = "A potent weapon capable of cutting through nearly anything. Wielding it in two hands will allow you to deflect gunfire."
+	force = 20
 	force_unwielded = 20
 	force_wielded = 40
 	armour_penetration = 100
@@ -845,9 +858,10 @@
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
 	name = "bone spear"
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
-	force = 11
+	force = 15
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
+	force_unwielded = 15
 	force_wielded = 32
 	throwforce = 25
 	throwforce = 20
@@ -908,6 +922,7 @@
 	icon_state = "baseball0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	force = 15
 	force_unwielded = 15
 	force_wielded = 30
 	throwforce = 15
@@ -927,8 +942,9 @@
 	icon_state = "baseballspike0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	force_unwielded = 25
-	force_wielded = 40
+	force = 20
+	force_unwielded = 20
+	force_wielded = 35
 	throwforce = 20
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("beat", "smacked", "clubbed", "clobbered")
@@ -946,9 +962,10 @@
 	icon_state = "sledgehammer0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	force_unwielded = 20
+	force = 25
+	force_unwielded = 25
 	force_wielded = 45
-	throwforce = 20
+	throwforce = 30
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb = list("bashed", "pounded", "bludgeoned", "pummeled", "thrashed")
 	w_class = WEIGHT_CLASS_BULKY
@@ -977,6 +994,7 @@
 	icon_state = "supersledge0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	force = 25
 	force_unwielded = 25
 	force_wielded = 60
 
@@ -991,6 +1009,7 @@
 	icon_state = "atom_hammer0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	force = 25
 	force_unwielded = 25
 	force_wielded = 60
 
@@ -1010,8 +1029,9 @@
 	icon_state = "warmace0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
-	force_unwielded = 20
-	force_wielded = 40
+	force = 25
+	force_unwielded = 25
+	force_wielded = 45
 	throwforce = 20
 	armour_penetration = 20
 	slot_flags = ITEM_SLOT_BACK
@@ -1029,6 +1049,7 @@
 	icon_state = "shamanstaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/polearms_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/polearms_righthand.dmi'
+	force = 15
 	force_unwielded = 15
 	force_wielded = 30
 	slot_flags = ITEM_SLOT_BACK

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -132,6 +132,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	force = 25
 	sharpness = IS_BLUNT
 
+/obj/item/claymore/machete/pipe/Initialize()
+	. = ..()
+	var/datum/component/jousting/JC = AddComponent(/datum/component/jousting)
+	JC.unmounted_knockdown_chance_per_tile = 15
+	JC.unmounted_knockdown_time = 50
+	JC.mounted_damage_boost_per_tile = 15
+	JC.mounted_knockdown_chance_per_tile = 15
+
 /obj/item/claymore/machete/warclub
 	name = "war club"
 	desc = "A simple carved wooden club with turquoise inlays."
@@ -143,6 +151,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	block_chance = 10
 	armour_penetration = 5
 	sharpness = IS_BLUNT
+
+/obj/item/claymore/machete/warclub/Initialize()
+	. = ..()
+	var/datum/component/jousting/JC = AddComponent(/datum/component/jousting)
+	JC.unmounted_knockdown_chance_per_tile = 25
+	JC.unmounted_knockdown_time = 50
+	JC.mounted_damage_boost_per_tile = 20
+	JC.mounted_knockdown_chance_per_tile = 20
 
 /obj/item/claymore/machete/pipe/tireiron
 	name = "tire iron"
@@ -159,6 +175,12 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	attack_verb = list("mashed", "bashed", "piped", "hit", "bludgeoned", "whacked", "bonked")
 	force = 25
 	sharpness = IS_BLUNT
+
+/obj/item/claymore/machete/golf/Initialize()
+	. = ..()
+	var/datum/component/jousting/JC = AddComponent(/datum/component/jousting)
+	JC.mounted_damage_boost_per_tile = 25
+	JC.mounted_knockdown_chance_per_tile = 25
 
 /obj/item/claymore/machete/golf/teniron
 	name = "10 iron"
@@ -646,6 +668,15 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	throwforce = 4
 	w_class = WEIGHT_CLASS_HUGE
 	attack_verb = list("smacked", "whacked", "slammed", "smashed")
+
+//This is literally wacking someone with a skateboard, not riding it. Okay
+/obj/item/melee/skateboard/Initialize()
+	. = ..()
+	var/datum/component/jousting/JC = AddComponent(/datum/component/jousting)
+	JC.unmounted_knockdown_chance_per_tile = 20
+	JC.unmounted_knockdown_time = 10
+	JC.mounted_damage_boost_per_tile = 25
+	JC.mounted_knockdown_chance_per_tile = 20
 
 /obj/item/melee/skateboard/attack_self(mob/user)
 	new /obj/vehicle/ridden/scooter/skateboard(get_turf(user))


### PR DESCRIPTION
## Description
Updates and improves jousting and enables building momentum and "charge attacks" while unmounted on certain weapons. 

Some twohanded weapons got improved one handed damage because they were hilariously, spectacularly low and some didn't have any initial force set at all. 

## Motivation and Context
Jousting was a bit wonky and not easily used, two handed weapons in one hand were pitifully low due to old TG stuff

## How Has This Been Tested?
Tested it on local and beat the shit out of some mobs

## Screenshots (if appropriate):
https://i.imgur.com/B3CrwP0.gif

## Changelog (necessary)
:cl:
tweak: Some updates to the jousting subsystem and adds joust component to many appropriate melee weapons. Also tightens up a few forgotten weapon forces.
/:cl:
