### PR TITLE
BoS Exile turtleneck

### DIFF
--- a/code/modules/jobs/job_types/wasteland.dm
+++ b/code/modules/jobs/job_types/wasteland.dm
@@ -311,6 +311,7 @@ Raider
 /datum/outfit/loadout/raider_bos
 	name = "Brotherhood Exile"
 	suit = /obj/item/clothing/suit/armor/f13/exile/bosexile
+	uniform = /obj/item/clothing/under/syndicate
 	id = /obj/item/card/id/rusted/brokenholodog
 	backpack_contents = list(
 		/obj/item/gun/energy/laser/pistol=1,


### PR DESCRIPTION
Adds a tactical turtleneck to the BoS exile loadout, otherwise they spawn with regular raider clothes, unlike the NCR & Legion deserters who get their own uniforms.
