### PR TITLE
Adds a Medical Belt, a Pip-Boy and a Health Analyzer to the Followers' Doctor's Paramedic loadout

### DIFF
--- a/code/modules/jobs/job_types/followers.dm
+++ b/code/modules/jobs/job_types/followers.dm
@@ -196,8 +196,12 @@ Practitioner
 	name = "Paramedic"
 	head = /obj/item/clothing/head/soft/emt
 	suit = /obj/item/clothing/suit/toggle/labcoat/emt
+	glasses = /obj/item/clothing/glasses/hud/health
+	belt = /obj/item/storage/belt/medical
 	backpack_contents = list(
-		/obj/item/reagent_containers/medspray/synthflesh=2)
+		/obj/item/reagent_containers/medspray/synthflesh=2,
+		/obj/item/pda/medical=1,
+		/obj/item/healthanalyzer=1)
 
 /datum/outfit/loadout/medical_researcher
 	name = "Medical Researcher"


### PR DESCRIPTION


## Description
Pretty much nothing that isn't in the title.

## Motivation and Context
The Paramedic Loadout right now is objectively the worst choice among all possible loadouts. I added a few perks that the Emergency Phys doesn't have to make it a valid side choice.

## How Has This Been Tested?
Just compiled the code to see if it worked. Everything ran fine.

## Changelog (necessary)
:cl:
add: Added a Medical Belt, a Pip-Boy and a Health Analyzer to the Followers' Doctor's Paramedic loadout
/:cl:
