### PR TITLE
Adds gauss rifle ammo to the autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -824,6 +824,14 @@
 	materials = list(MAT_METAL = 50000)
 	build_path = /obj/item/ammo_box/a50MG/incendiary
 	category = list("initial", "Security")
+	
+/datum/design/m2mm
+	name = "2mm Electromagnetic Magazine"
+	id = "m2mm"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 50000)
+	build_path = /obj/item/ammo_box/magazine/m2mm
+	category = list("initial", "Security")
 
 /*
 /datum/design/a50MGAP


### PR DESCRIPTION
What it says on the tin. The gauss rifle currently has no way to obtain more ammo outside of admin spawns, which limits a Senior Paladin that chooses it at roundstart to having only 30 bullets for the whole round. This adds it to the autolathe with the same material cost as .50 incendiary rounds, and only makes a single magazine, which is 10 extra shots. This also requires the autolathe to be upgraded with a part 4, high quality metal parts and a makeshift reloader, which balances it out IMO.
