### PR TITLE
prime decanus fix

### DIFF
--- a/code/modules/jobs/job_types/legion.dm
+++ b/code/modules/jobs/job_types/legion.dm
@@ -388,7 +388,7 @@ Decanii
 	jobtype = /datum/job/CaesarsLegion/Legionnaire/f13decan
 	id = 			/obj/item/card/id/dogtag/legveteran
 	suit =			/obj/item/clothing/suit/armor/f13/legion/vet
-	head =			/obj/item/clothing/head/helmet/f13/legion/prime/alt
+	head =			/obj/item/clothing/head/helmet/f13/legion/prime/decan
 	mask =			/obj/item/clothing/mask/bandana/legdecan
 	glasses = 		/obj/item/clothing/glasses/sunglasses/big
 	ears = 			/obj/item/radio/headset/headset_legion


### PR DESCRIPTION
LITERALLY fixes the prime decanus leadout.

![image](https://user-images.githubusercontent.com/46762013/100414149-0505a780-3047-11eb-9132-7cbc43d9d1e0.png)

That's it. They used to spawn with the wrong helmet, which was the alternative prime LEGIONARY helmet, instead of the prime DECANUS helmet. They no longer spawn with the wrong helmet.