### PR TITLE
Stable Plasma Recipe

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -35,6 +35,13 @@
 	results = list("sodiumchloride" = 3)
 	required_reagents = list("water" = 1, "sodium" = 1, "chlorine" = 1)
 
+/datum/chemical_reaction/stable_plasma
+	name = "stable plasma"
+	id = "stable_plasma"
+	results = list("stable_plasma" = 1)
+	required_reagents = list("plasma" = 1)
+	required_catalysts = list("stabilizing_agent" = 1)
+	
 /datum/chemical_reaction/plasmasolidification
 	name = "Solid Plasma"
 	id = "solidplasma"


### PR DESCRIPTION

<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds a stable plasma recipe. Even if you're some kind of psychopath, you can't just make a massive plasmafire because the stabilizing agent stabilizes the chemical recipes. And if you're a doctor, you can just take the stabilizing agent out with a chemmaster. Therefore, it is safe for ghetto use. Definitely. Totally.
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Same as the sulphuric acid recipe. It's in TG today, but this code is wack and old. Doctors with empty chem dispensers, fret not. You can now make stable plasma normally.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- This helps us replicate your tests, to speed up review. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Private server. Worked. Combined the proper reagents. Stabilizing agent was not consumed, successfully made the stable plasma, made some stuff with the stable plasma. I did not die instantly.
## Screenshots (if appropriate):
https://gyazo.com/3185778d2f30c07628ba1531fa47ae2a
## Changelog (necessary)
:cl:
- added stable plasma recipe
/:cl:
