### PR TITLE
Removes icon world.log, tweaks icons, fixes dupe

### DIFF
--- a/code/modules/client/asset_cache.dm
+++ b/code/modules/client/asset_cache.dm
@@ -652,10 +652,9 @@ GLOBAL_LIST_EMPTY(asset_datums)
 		var/icon_file = tmp[1]
 		var/icon_state = tmp[2]
 		var/c = LAZYACCESS(tmp, 3)
-		var/icon_string = "[sanitize_filename(replacetext(replacetext(icon_file, "icons/", ""), ".dmi", ""))]-[icon_state]"
+		var/icon_string = "[sanitize_filename(replacetext(icon_file, ".dmi", ""))]-[icon_state]"
 		var/icon/I
 
-		world.log << icon_file
 		if(!fexists(icon_file))
 			stack_trace("Invalid icon file [icon_file]")
 			continue

--- a/code/modules/jobs/loadout_ingame.dm
+++ b/code/modules/jobs/loadout_ingame.dm
@@ -152,7 +152,9 @@
 		if("loadout_select")
 			select_outfit(params["name"])
 		if("loadout_confirm")
-			if (!confirming && selected_datum)
+			if(confirming)
+				return // No duplication.
+			if (selected_datum)
 				confirming = TRUE
 				var/response = alert(usr, "Are you sure you wish to finish loadout selection? The currently selected outfit will be spawned in a box, which will be placed in your hand.", "Confirm Loadout Select", "Yes, I'm done.", "No, wait!")
 				if (response == "Yes, I'm done.")

--- a/code/modules/research/designs.dm
+++ b/code/modules/research/designs.dm
@@ -66,7 +66,7 @@ other types of metals and chemistry for reagents).
 		if (machine)
 			item = machine
 	var/icon_file = "[initial(item.icon)]"
-	var/icon_string = "[sanitize_filename(replacetext(replacetext(icon_file, "icons/", ""), ".dmi", ""))]-[initial(item.icon_state)]"
+	var/icon_string = "[sanitize_filename(replacetext(icon_file, ".dmi", ""))]-[initial(item.icon_state)]"
 	// computers (and snowflakes) get their screen and keyboard sprites
 	if (ispath(item, /obj/machinery/computer) || ispath(item, /obj/machinery/power/solar_control))
 		var/obj/machinery/computer/C = item


### PR DESCRIPTION
<!-- Thanks for choosing to take the time to contribute to our project! We have a few things below that we'd like you to fill out -->
<!-- The more detail you can give us, the faster we can code review, test, and merge your changes -->

<!--- Provide a general summary of your changes in the Title above -->

## Description
Removes a `world.log` statement in iconsheet code that just slowed stuff down with unnecessary log statements.
Tweaks loadout icon sheet generation to avoid a potential path conflict I found on the rebase.
Fixes loadout dupe bug.

## Motivation and Context
World.log slowed stuff down, dupe bug leads to loadout item duplication which can be extremely OP, icon path tweak prevents conflicts.

## How Has This Been Tested?
I spawned in to try and reproduce the loadout dupe bug, forgot I had already compiled the fix, and was confused when I couldn't reproduce the bug.

## Screenshots (if appropriate):
N/A

## Changelog (necessary)
:cl:
fix: fixed a loadout duplication bug
code: tweaked sprite paths in spritesheet generation
server: Removes an unnecessary world.log << icon_file from loadout spritesheet generation code.
/:cl:
